### PR TITLE
Speculative decoding support (target + draft)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,16 @@
+# Include the llama.cpp integration patch + apply script. README directs
+# users to `cd kernel-anvil/patches && ./apply.sh`, so the sdist must
+# carry that directory.
+recursive-include patches *
+
+# Include example Triton runner scripts referenced from README usage.
+recursive-include examples *
+
+include LICENSE
+include README.md
+
+# Don't ship build artifacts in the sdist.
+global-exclude __pycache__
+global-exclude *.pyc
+global-exclude *.pyo
+global-exclude .DS_Store

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Profile-guided GPU kernel optimizer for AMD. Reads a GGUF model, profiles each layer's GEMV shape on your GPU, and generates optimal kernel configs that llama.cpp loads at runtime. No recompilation needed.
 
-**2x decode speedup on Qwen3.5-27B** (12 -> 27 tok/s on a 7900 XTX) from shape-specific kernel tuning alone.
+**2.25x decode speedup on Qwen3.5-27B** (12 -> 27 tok/s on a 7900 XTX) from shape-specific kernel tuning alone.
 
 ## How It Works
 
@@ -47,8 +47,41 @@ SMITHY_CONFIG=~/.cache/smithy/Qwen3-8B-Q4_K_M.json \
 
 On startup:
 ```
-smithy: loaded 6 shape-specific kernel configs from ~/.cache/smithy/Qwen3-8B-Q4_K_M.json
+kernel-anvil: loaded 6 shape configs from ~/.cache/smithy/Qwen3-8B-Q4_K_M.json
 ```
+
+### Speculative decoding (target + draft)
+
+llama.cpp's speculative decoding loads two models concurrently (a large target plus a small draft). Both run through the same MMVQ dispatch path, so a single merged config covers both.
+
+The simplest path is to profile both models in one shot:
+
+```bash
+kernel-anvil gguf-optimize ~/Models/Qwen3-8B-Q4_K_M.gguf \
+    --draft ~/Models/Qwen3-0.6B-Q4_K_M.gguf
+
+SMITHY_CONFIG=~/.cache/smithy/Qwen3-8B-Q4_K_M.json \
+    llama-server -m ~/Models/Qwen3-8B-Q4_K_M.gguf \
+                 -md ~/Models/Qwen3-0.6B-Q4_K_M.gguf -ngl 999
+```
+
+`--draft` may be passed more than once to register multiple draft candidates. When two profiled shapes from different models land in the same `(quant, N_bucket, K_bucket)` cell, the config with the better profiled speedup wins.
+
+If you already have separate caches from earlier `gguf-optimize` runs, merge them:
+
+```bash
+kernel-anvil merge-configs \
+    ~/.cache/smithy/Qwen3-8B-Q4_K_M.json \
+    ~/.cache/smithy/Qwen3-0.6B-Q4_K_M.json \
+    -o ~/.cache/smithy/spec-decode.json
+
+SMITHY_CONFIG=~/.cache/smithy/spec-decode.json \
+    llama-server -m target.gguf -md draft.gguf -ngl 999
+```
+
+Argument order is priority order -- the first input wins on bucket-cell conflicts. Pass the target first.
+
+No llama.cpp patch changes are needed for either workflow; the runtime loader is already model-agnostic.
 
 ### Profile a Triton kernel
 
@@ -56,6 +89,16 @@ smithy: loaded 6 shape-specific kernel configs from ~/.cache/smithy/Qwen3-8B-Q4_
 kernel-anvil sweep examples/simple_gemv.py
 kernel-anvil profile examples/simple_gemv.py
 ```
+
+### Other commands
+
+| Command | Purpose |
+|---------|---------|
+| `autoforge <gguf>` | Generate, compile, and benchmark shape-specific HIP kernels via hipcc |
+| `llama-sweep <gguf>` | Sweep llama.cpp MMVQ kernel configs against real hardware (requires rocprofv3) |
+| `compare-backends <gguf>` | Head-to-head ROCm vs Vulkan decode comparison |
+
+Run `kernel-anvil <command> --help` for full options.
 
 ## Results
 
@@ -158,7 +201,7 @@ The profiling + sweep runs on any GPU that supports PyTorch + Triton. Hardware s
 ## Testing
 
 ```bash
-python -m pytest tests/ -v   # 193 tests
+python -m pytest tests/ -v
 ```
 
 ## Related Work

--- a/kernel_anvil/cli.py
+++ b/kernel_anvil/cli.py
@@ -333,12 +333,103 @@ def _tune_shape_cli(
     return codegen_config, baseline_latency, speedup
 
 
+def _profile_gguf_shapes(
+    profile,
+    *,
+    no_bench: bool,
+    gpu_spec,
+    device,
+    args,
+    label: str,
+    codegen_configs: dict,
+    results_table: list,
+    speedups: dict[tuple[str, int, int], float],
+):
+    """Tune every unique shape in ``profile`` and accumulate into the shared
+    output dicts. Skips shapes already tuned by a previous model in the same
+    invocation (target+draft sharing).
+
+    On profiling failure for a shape, the slot is left ABSENT from
+    ``codegen_configs`` (recorded in ``results_table`` as a FAIL row) so a
+    subsequent draft model sharing that shape gets a fresh profiling
+    attempt instead of being silently locked into the failure config."""
+    shapes = profile.unique_shapes
+    label_prefix = f"[{label}] " if label else ""
+
+    if no_bench:
+        console.print(f"[bold]{label_prefix}Generating heuristic configs for {len(shapes)} shapes...[/bold]\n")
+        for i, ((qt, n, k), count) in enumerate(sorted(shapes.items()), 1):
+            if (qt, n, k) in codegen_configs:
+                console.print(f"  {label_prefix}[{i}/{len(shapes)}] {qt} ({n}, {k}) x{count}: [dim]reused[/dim]")
+                continue
+            blocks_per_row = k // 256 if k >= 256 else 1
+            if blocks_per_row < 64:
+                cfg = {"nwarps": 2, "rows_per_block": 2}
+            else:
+                cfg = {"nwarps": 4, "rows_per_block": 1}
+            codegen_configs[(qt, n, k)] = cfg
+            console.print(f"  {label_prefix}[{i}/{len(shapes)}] {qt} ({n}, {k}) x{count}: "
+                          f"nwarps={cfg['nwarps']} rows={cfg['rows_per_block']} (heuristic)")
+            results_table.append((label, qt, n, k, count, cfg, 0, None, 0))
+        return
+
+    console.print(f"[bold]{label_prefix}Tuning {len(shapes)} unique GEMV workloads...[/bold]\n")
+    for i, ((qt, n, k), count) in enumerate(sorted(shapes.items()), 1):
+        if (qt, n, k) in codegen_configs:
+            console.print(f"  {label_prefix}[{i}/{len(shapes)}] {qt} ({n}, {k}) x{count}: [dim]reused[/dim]")
+            continue
+        console.print(
+            f"  {label_prefix}[{i}/{len(shapes)}] {qt} ({n}, {k}) x{count}...",
+            end=" ",
+        )
+        t0 = time.monotonic()
+        try:
+            cfg, baseline_us, speedup = _tune_shape_cli(
+                N=n, K=k, device=device, gpu_spec=gpu_spec,
+                max_configs=args.max_configs, warmup=args.warmup, runs=args.runs,
+            )
+            dt = time.monotonic() - t0
+            speedup_str = f"{speedup:.2f}x" if speedup is not None else "-"
+            console.print(
+                f"nwarps={cfg['nwarps']} rows={cfg['rows_per_block']} "
+                f"({speedup_str}, {dt:.1f}s)"
+            )
+            codegen_configs[(qt, n, k)] = cfg
+            if speedup is not None:
+                speedups[(qt, n, k)] = float(speedup)
+            results_table.append((label, qt, n, k, count, cfg, baseline_us, speedup, dt))
+        except Exception as e:
+            console.print(f"[red]FAILED: {e}[/red]")
+            # Don't poison the slot: leave (qt, n, k) absent from
+            # codegen_configs so a subsequent draft model with the same shape
+            # can still try profiling it. The results_table tracks the
+            # failure for the user-visible summary.
+            results_table.append((label, qt, n, k, count, None, 0, None, 0))
+
+
 def cmd_gguf_optimize(args):
-    """Parse GGUF, tune each unique shape, emit C header."""
+    """Parse GGUF (and optional draft GGUFs), tune each unique GEMV shape,
+    and write a runtime JSON config to ``~/.cache/smithy/<stem>.json``.
+
+    With ``--draft <gguf>`` (repeatable), profiles target and draft(s)
+    together and merges into a single config keyed under the target stem.
+    Bucket-cell collisions resolve to the higher profiled speedup so the
+    better-performing config survives.
+
+    A C header is also emitted when ``--output`` is explicitly set to a
+    non-default path."""
     gguf_path = Path(args.gguf)
     if not gguf_path.exists():
         console.print(f"[red]GGUF file not found: {gguf_path}[/red]")
         sys.exit(1)
+
+    draft_paths: list[Path] = []
+    for raw in getattr(args, "draft", None) or []:
+        dp = Path(raw)
+        if not dp.exists():
+            console.print(f"[red]Draft GGUF not found: {dp}[/red]")
+            sys.exit(1)
+        draft_paths.append(dp)
 
     # Check GPU (skip if --no-bench)
     no_bench = getattr(args, "no_bench", False)
@@ -358,76 +449,53 @@ def cmd_gguf_optimize(args):
         gpu_spec = _get_gpu_spec()
         device = torch.device("cuda")
 
-    # Parse GGUF
-    console.print(f"\n[bold]Parsing {gguf_path.name}...[/bold]")
-    profile = parse_gguf(str(gguf_path))
-
-    # Print model summary
+    # Parse target (and optional drafts)
+    console.print(f"\n[bold]Parsing target {gguf_path.name}...[/bold]")
+    target_profile = parse_gguf(str(gguf_path))
     console.print()
-    print_model_summary(profile)
+    print_model_summary(target_profile)
     console.print()
 
-    # Collect unique 2D shapes to tune
-    shapes = profile.unique_shapes
-    if not shapes:
-        console.print("[yellow]No 2D weight tensors found in model.[/yellow]")
+    draft_profiles = []
+    for dp in draft_paths:
+        console.print(f"\n[bold]Parsing draft {dp.name}...[/bold]")
+        dprof = parse_gguf(str(dp))
+        console.print()
+        print_model_summary(dprof)
+        console.print()
+        draft_profiles.append((dp, dprof))
+
+    if not target_profile.unique_shapes and not any(p.unique_shapes for _, p in draft_profiles):
+        console.print("[yellow]No 2D weight tensors found in any model.[/yellow]")
         sys.exit(0)
 
     codegen_configs: dict[tuple[str, int, int], dict] = {}
-    results_table = []
+    speedups: dict[tuple[str, int, int], float] = {}
+    results_table: list = []
     total_t0 = time.monotonic()
 
-    if no_bench:
-        # Heuristic mode: assign configs based on shape analysis, no GPU needed
-        console.print(f"[bold]Generating heuristic configs for {len(shapes)} shapes...[/bold]\n")
-        for i, ((qt, n, k), count) in enumerate(sorted(shapes.items()), 1):
-            blocks_per_row = k // 256 if k >= 256 else 1
-            # Heuristic: fewer warps for small K (less sync overhead)
-            if blocks_per_row < 64:  # small_k
-                cfg = {"nwarps": 2, "rows_per_block": 2}
-            else:
-                cfg = {"nwarps": 4, "rows_per_block": 1}
-            codegen_configs[(qt, n, k)] = cfg
-            console.print(f"  [{i}/{len(shapes)}] {qt} ({n}, {k}) x{count}: "
-                          f"nwarps={cfg['nwarps']} rows={cfg['rows_per_block']} (heuristic)")
-            results_table.append((qt, n, k, count, cfg, 0, None, 0))
-    else:
-        console.print(f"[bold]Tuning {len(shapes)} unique GEMV workloads...[/bold]\n")
-
-        for i, ((qt, n, k), count) in enumerate(sorted(shapes.items()), 1):
-            console.print(
-                f"  [{i}/{len(shapes)}] {qt} ({n}, {k}) x{count}...",
-                end=" ",
-            )
-            t0 = time.monotonic()
-            try:
-                cfg, baseline_us, speedup = _tune_shape_cli(
-                    N=n,
-                    K=k,
-                    device=device,
-                    gpu_spec=gpu_spec,
-                    max_configs=args.max_configs,
-                    warmup=args.warmup,
-                    runs=args.runs,
-                )
-                dt = time.monotonic() - t0
-                speedup_str = f"{speedup:.2f}x" if speedup is not None else "-"
-                console.print(
-                    f"nwarps={cfg['nwarps']} rows={cfg['rows_per_block']} "
-                    f"({speedup_str}, {dt:.1f}s)"
-                )
-                codegen_configs[(qt, n, k)] = cfg
-                results_table.append((qt, n, k, count, cfg, baseline_us, speedup, dt))
-            except Exception as e:
-                console.print(f"[red]FAILED: {e}[/red]")
-                codegen_configs[(qt, n, k)] = {"nwarps": 4, "rows_per_block": 1}
-                results_table.append((qt, n, k, count, {"nwarps": 4, "rows_per_block": 1}, 0, None, 0))
+    _profile_gguf_shapes(
+        target_profile,
+        no_bench=no_bench, gpu_spec=gpu_spec, device=device, args=args,
+        label="target" if draft_profiles else "",
+        codegen_configs=codegen_configs, results_table=results_table, speedups=speedups,
+    )
+    for idx, (_, dprof) in enumerate(draft_profiles, start=1):
+        label = "draft" if len(draft_profiles) == 1 else f"draft{idx}"
+        _profile_gguf_shapes(
+            dprof,
+            no_bench=no_bench, gpu_spec=gpu_spec, device=device, args=args,
+            label=label,
+            codegen_configs=codegen_configs, results_table=results_table, speedups=speedups,
+        )
 
     total_dt = time.monotonic() - total_t0
 
     # Print results summary table
     console.print()
     table = Table(title="Optimization Results")
+    if draft_profiles:
+        table.add_column("Source", style="magenta")
     table.add_column("Quant", style="cyan")
     table.add_column("N", justify="right")
     table.add_column("K", justify="right")
@@ -438,21 +506,21 @@ def cmd_gguf_optimize(args):
     table.add_column("Speedup", justify="right")
     table.add_column("Time", justify="right", style="dim")
 
-    for qt, n, k, count, cfg, baseline_us, speedup, dt in results_table:
+    for label, qt, n, k, count, cfg, baseline_us, speedup, dt in results_table:
         speedup_str = f"[green]{speedup:.2f}x[/green]" if speedup is not None and speedup > 1.0 else (
             f"{speedup:.2f}x" if speedup is not None else "-"
         )
-        table.add_row(
-            qt,
-            str(n),
-            str(k),
-            str(count),
-            str(cfg["nwarps"]),
-            str(cfg["rows_per_block"]),
+        nwarps_str = str(cfg["nwarps"]) if cfg else "[red]FAIL[/red]"
+        rpb_str = str(cfg["rows_per_block"]) if cfg else "[red]FAIL[/red]"
+        row = [
+            qt, str(n), str(k), str(count),
+            nwarps_str, rpb_str,
             f"{baseline_us:.1f}" if baseline_us else "-",
-            speedup_str,
-            f"{dt:.1f}s",
-        )
+            speedup_str, f"{dt:.1f}s",
+        ]
+        if draft_profiles:
+            row.insert(0, label or "target")
+        table.add_row(*row)
 
     console.print(table)
     console.print(f"\nTotal tuning time: {total_dt:.1f}s")
@@ -460,10 +528,17 @@ def cmd_gguf_optimize(args):
     # Generate runtime JSON config for llama.cpp auto-loading
     from kernel_anvil.codegen import generate_runtime_config
 
+    if draft_profiles:
+        names = [target_profile.name] + [p.name for _, p in draft_profiles]
+        merged_model_name = "+".join(names)
+    else:
+        merged_model_name = target_profile.name
+
     json_config = generate_runtime_config(
         codegen_configs,
         gpu_name=gpu_spec.gfx,
-        model_name=profile.name,
+        model_name=merged_model_name,
+        priorities=speedups if draft_profiles else None,
     )
 
     # Write to ~/.cache/smithy/<model_basename>.json for auto-loading
@@ -479,22 +554,106 @@ def cmd_gguf_optimize(args):
         with os.fdopen(tmp_fd, "w") as f:
             f.write(json_config)
         os.rename(tmp_path, str(cache_path))
-    except Exception:
-        os.unlink(tmp_path)
-        raise
+    finally:
+        # Whether rename succeeded, raised OSError, or was aborted by an
+        # unrelated exception (KeyboardInterrupt, MemoryError, etc.), make
+        # sure we don't leak tempfiles in the cache dir.
+        if Path(tmp_path).exists():
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
     console.print(f"\n[bold green]Config cached to {cache_path}[/bold green]")
-    console.print(f"[dim]Run: SMITHY_MODEL={args.gguf} llama-server -m {args.gguf} -ngl 999[/dim]")
+    if draft_profiles:
+        # llama.cpp's llama-server only accepts ONE -md flag at runtime, so
+        # the hint emits a single draft. The merged config still covers any
+        # additional draft GGUFs the user passed via --draft, which is
+        # useful when iterating across draft candidates without re-tuning.
+        primary_draft = draft_profiles[0][0]
+        console.print(
+            f"[dim]Run: SMITHY_CONFIG={cache_path} llama-server "
+            f"-m {args.gguf} -md {primary_draft} -ngl 999[/dim]"
+        )
+        if len(draft_profiles) > 1:
+            extras = ", ".join(str(dp) for dp, _ in draft_profiles[1:])
+            console.print(
+                f"[dim]      (merged config also covers: {extras})[/dim]"
+            )
+    else:
+        console.print(
+            f"[dim]Run: SMITHY_MODEL={args.gguf} llama-server -m {args.gguf} -ngl 999[/dim]"
+        )
 
     # Also write C header if --output was explicitly set
     if args.output != "smithy-config.h":
         header = generate_config_header(
             codegen_configs,
             gpu_name=f"{gpu_spec.gfx} ({gpu_spec.name})",
-            model_name=profile.name,
+            model_name=merged_model_name,
         )
         output_path = Path(args.output)
         output_path.write_text(header)
         console.print(f"[dim]C header also written to {output_path}[/dim]")
+
+
+def cmd_merge_configs(args):
+    """Merge multiple kernel-anvil JSON configs into one.
+
+    Useful for speculative-decoding setups: profile each model separately
+    (target + draft) with ``gguf-optimize``, then point ``SMITHY_CONFIG`` at
+    the merged output. First-listed input wins on bucket-cell collisions.
+    """
+    import json
+    from kernel_anvil.codegen import merge_runtime_configs
+
+    payloads = []
+    for raw in args.inputs:
+        p = Path(raw)
+        if not p.exists():
+            console.print(f"[red]Config not found: {p}[/red]")
+            sys.exit(1)
+        try:
+            with open(p) as f:
+                payloads.append(json.load(f))
+        except json.JSONDecodeError as e:
+            console.print(f"[red]Invalid JSON in {p}: {e}[/red]")
+            sys.exit(1)
+
+    try:
+        merged = merge_runtime_configs(
+            payloads,
+            gpu_name=args.gpu,
+            model_name=args.model,
+        )
+    except (TypeError, ValueError, AttributeError) as e:
+        console.print(f"[red]Invalid config payload: {e}[/red]")
+        sys.exit(1)
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    # Atomic write: write to temp file in the same dir, then rename. Mirrors
+    # the cmd_gguf_optimize pattern; prevents truncated output if two
+    # merge-configs runs target the same path or the process is killed.
+    import tempfile
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(out_path.parent), suffix=".json.tmp")
+    try:
+        with os.fdopen(tmp_fd, "w") as f:
+            f.write(json.dumps(merged, indent=2))
+        os.rename(tmp_path, str(out_path))
+    finally:
+        # Always clean up the tempfile if it's still there (covers OSError,
+        # KeyboardInterrupt, MemoryError, anything that aborted the rename).
+        if Path(tmp_path).exists():
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    n_types = len(merged.get("configs") or {})
+    n_cells = sum(len(v) for v in (merged.get("configs") or {}).values())
+    console.print(f"[bold green]Merged {len(payloads)} configs -> {out_path}[/bold green]")
+    console.print(f"[dim]{n_types} quant types, {n_cells} bucket cells[/dim]")
+    console.print(f"[dim]Run: SMITHY_CONFIG={out_path} llama-server -m target.gguf -md draft.gguf -ngl 999[/dim]")
 
 
 def cmd_autoforge(args):
@@ -609,6 +768,23 @@ def main():
     p_gguf.add_argument("--warmup", type=int, default=3, help="Warmup iterations (default: 3)")
     p_gguf.add_argument("--runs", type=int, default=5, help="Timed iterations (default: 5)")
     p_gguf.add_argument("--no-bench", action="store_true", help="Skip GPU benchmarking, use heuristic configs (works without GPU)")
+    p_gguf.add_argument(
+        "--draft",
+        action="append",
+        metavar="GGUF",
+        help="Optional draft model GGUF (for speculative decoding). May be passed multiple times. "
+             "Profiles target + draft together and writes a single merged config keyed under the target stem.",
+    )
+
+    # merge-configs: combine multiple cached JSON configs into one
+    p_merge = sub.add_parser(
+        "merge-configs",
+        help="Merge multiple kernel-anvil JSON configs into one (e.g. for speculative decoding)",
+    )
+    p_merge.add_argument("inputs", nargs="+", help="Input config JSON files (priority = argument order)")
+    p_merge.add_argument("-o", "--output", required=True, help="Output merged config path")
+    p_merge.add_argument("--gpu", help="Override gpu field in merged output")
+    p_merge.add_argument("--model", help="Override model field in merged output")
 
     # autoforge: generate, compile, benchmark shape-specific kernels
     p_forge = sub.add_parser("autoforge", help="Auto-generate optimized HIP kernels for a model")
@@ -647,6 +823,8 @@ def main():
         cmd_autoforge(args)
     elif args.command == "compare-backends":
         cmd_compare(args)
+    elif args.command == "merge-configs":
+        cmd_merge_configs(args)
 
 
 if __name__ == "__main__":

--- a/kernel_anvil/codegen.py
+++ b/kernel_anvil/codegen.py
@@ -7,7 +7,6 @@ to select per-shape kernel configs at runtime.
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
@@ -68,12 +67,26 @@ def _bucket_label(idx: int) -> str:
 
 def build_config_tables(
     configs: dict[tuple[str, int, int], dict],
+    priorities: dict[tuple[str, int, int], float] | None = None,
 ) -> dict[str, list[list[ShapeConfig]]]:
     """Build bucketed config tables from sweep results.
+
+    Multiple (qt, N, K) triples can land in the same (qt, n_bucket, k_bucket)
+    cell. By default, the last (qt, N, K) entry that maps to a given cell
+    wins (iteration order over the configs dict). When ``priorities`` is
+    provided, the highest-priority entry wins per cell -- use the profiled
+    speedup so the better-performing config survives the bucket collision
+    (relevant for merging configs from multiple models, e.g. speculative
+    decoding target + draft pairs). NaN or missing priorities are coerced
+    to -inf so well-defined priorities always win over malformed ones.
 
     Args:
         configs: Mapping of (quant_type, N, K) -> {"nwarps": int, "rows_per_block": int}.
             The quant_type should match one of QUANT_TYPES (e.g. "Q4_K").
+        priorities: Optional parallel mapping of (quant_type, N, K) -> float
+            (typically profiled speedup). When two entries collide on a bucket
+            cell, the one with the higher priority wins. Missing keys are
+            treated as priority -inf.
 
     Returns:
         Dict mapping quant_type -> 2D list [n_bucket][k_bucket] of ShapeConfig.
@@ -81,23 +94,36 @@ def build_config_tables(
     """
     tables: dict[str, list[list[ShapeConfig]]] = {}
 
-    # Collect all quant types present in the data
     present_types = sorted({qt for qt, _, _ in configs})
 
     for qt in present_types:
-        # Initialize with defaults
         table = [[DEFAULT_CONFIG] * NUM_BUCKETS for _ in range(NUM_BUCKETS)]
+        cell_priority: dict[tuple[int, int], float] = {}
 
-        # Fill in sweep results
         for (q, n, k), cfg in configs.items():
             if q != qt:
                 continue
             ni = bucket_index(n)
             ki = bucket_index(k)
-            table[ni][ki] = ShapeConfig(
+            shape_cfg = ShapeConfig(
                 nwarps=cfg["nwarps"],
                 rows_per_block=cfg["rows_per_block"],
             )
+            if priorities is not None:
+                p = priorities.get((q, n, k))
+                # NaN must NOT win or lose silently: NaN compares False both
+                # ways, which would let it always overwrite a real priority.
+                # Treat NaN/None as -inf so well-defined priorities always
+                # win over malformed ones.
+                if p is None:
+                    p_val = float("-inf")
+                else:
+                    pf = float(p)
+                    p_val = float("-inf") if pf != pf else pf  # pf != pf <=> NaN
+                if (ni, ki) in cell_priority and p_val <= cell_priority[(ni, ki)]:
+                    continue
+                cell_priority[(ni, ki)] = p_val
+            table[ni][ki] = shape_cfg
 
         tables[qt] = table
 
@@ -108,6 +134,7 @@ def generate_runtime_config(
     configs: dict[tuple[str, int, int], dict],
     gpu_name: str = "gfx1100",
     model_name: str = "unknown",
+    priorities: dict[tuple[str, int, int], float] | None = None,
 ) -> str:
     """Generate a JSON config file for llama.cpp runtime loading.
 
@@ -126,10 +153,14 @@ def generate_runtime_config(
         }
       }
     }
+
+    When ``priorities`` is provided (typically per-shape profiled speedup),
+    bucket-cell collisions resolve to the higher-priority entry. This is how
+    speculative-decoding configs from a target+draft pair are merged.
     """
     import json
 
-    tables = build_config_tables(configs)
+    tables = build_config_tables(configs, priorities=priorities)
 
     out = {"gpu": gpu_name, "model": model_name, "configs": {}}
 
@@ -150,6 +181,83 @@ def generate_runtime_config(
             out["configs"][str(type_idx)] = type_configs
 
     return json.dumps(out, indent=2)
+
+
+def merge_runtime_configs(
+    payloads: list[dict],
+    gpu_name: str | None = None,
+    model_name: str | None = None,
+) -> dict:
+    """Merge already-serialized runtime config payloads (loaded from JSON).
+
+    Used to combine configs from multiple ``gguf-optimize`` runs (e.g. a
+    speculative-decoding target + draft pair) into a single config that
+    llama.cpp loads via SMITHY_CONFIG.
+
+    Resolution policy: first-seen wins. Earlier payloads in ``payloads`` take
+    priority over later ones for any overlapping (type_idx, n_bucket, k_bucket)
+    cell. Callers control priority via argument order -- pass the most
+    important model (typically the target) first.
+
+    Malformed payloads (non-dict at any level: payload, configs map, per-type
+    map, individual cell config) are silently skipped rather than raising,
+    so partial / mistyped JSON degrades to omitted entries instead of
+    crashing the whole merge.
+
+    Args:
+        payloads: List of parsed JSON payloads, each shaped like
+            ``{"gpu": ..., "model": ..., "configs": {type_idx: {"n,k": {...}}}}``.
+        gpu_name: Override for the merged ``gpu`` field. If None, uses the
+            first payload's value (or "unknown").
+        model_name: Override for the merged ``model`` field. If None, joins
+            the input model names with ``+``.
+
+    Returns:
+        A merged payload dict in the same shape, ready for ``json.dumps``.
+    """
+    if not payloads:
+        return {"gpu": gpu_name or "unknown", "model": model_name or "merged", "configs": {}}
+
+    # Defensively skip malformed payloads / configs / cells rather than
+    # raising an AttributeError into the caller. The CLI loads these from
+    # user-supplied JSON, so partial / mistyped data must degrade to "skip
+    # this entry" instead of crashing the whole merge.
+    merged_configs: dict[str, dict[str, dict]] = {}
+    valid_payloads: list[dict] = []
+    for payload in payloads:
+        if not isinstance(payload, dict):
+            continue
+        valid_payloads.append(payload)
+        cfgs = payload.get("configs") or {}
+        if not isinstance(cfgs, dict):
+            continue
+        for type_idx, cells in cfgs.items():
+            if not isinstance(cells, dict):
+                continue
+            type_bucket = merged_configs.setdefault(str(type_idx), {})
+            for cell_key, cell_cfg in cells.items():
+                if cell_key in type_bucket:
+                    continue  # first-seen wins
+                if not isinstance(cell_cfg, dict):
+                    continue
+                type_bucket[str(cell_key)] = dict(cell_cfg)
+
+    if gpu_name is not None:
+        out_gpu = gpu_name
+    else:
+        gpu_field = valid_payloads[0].get("gpu") if valid_payloads else None
+        out_gpu = gpu_field if isinstance(gpu_field, str) else "unknown"
+
+    if model_name is not None:
+        out_model = model_name
+    else:
+        names = []
+        for p in valid_payloads:
+            m = p.get("model")
+            names.append(m if isinstance(m, str) else "unknown")
+        out_model = "+".join(names) if names else "merged"
+
+    return {"gpu": out_gpu, "model": out_model, "configs": merged_configs}
 
 
 def generate_config_header(

--- a/kernel_anvil/hip_codegen.py
+++ b/kernel_anvil/hip_codegen.py
@@ -20,7 +20,6 @@ Two codegen paths:
 
 from __future__ import annotations
 
-import math
 import os
 import subprocess
 import tempfile

--- a/kernel_anvil/llama_sweep.py
+++ b/kernel_anvil/llama_sweep.py
@@ -21,6 +21,7 @@ import os
 import re
 import sqlite3
 import subprocess
+import sys
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -64,10 +65,19 @@ def _parse_rocprof_db(db_path: str) -> list[KernelTiming]:
     """Parse rocprofv3 SQLite database for MMVQ kernel timings."""
     db = sqlite3.connect(db_path)
 
-    # Find the UUID suffix for this run's tables
+    # Find the UUID suffix for this run's tables. Use ESCAPE so the literal
+    # underscores in the prefix don't act as LIKE single-char wildcards
+    # (which would match e.g. 'rocpd_kernel_dispatchABC' and pass the
+    # safe-identifier validator while later pointing at a non-existent
+    # symbol table).
     tables = [r[0] for r in db.execute(
-        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'rocpd_kernel_dispatch_%'"
+        "SELECT name FROM sqlite_master WHERE type='table' "
+        r"AND name LIKE 'rocpd\_kernel\_dispatch\_%' ESCAPE '\'"
     ).fetchall()]
+
+    # Defensive belt-and-braces: even with the escape, only accept names
+    # that literally start with the expected prefix.
+    tables = [t for t in tables if t.startswith("rocpd_kernel_dispatch_")]
 
     if not tables:
         db.close()
@@ -88,18 +98,24 @@ def _parse_rocprof_db(db_path: str) -> list[KernelTiming]:
         db.close()
         return []
 
-    rows = db.execute(f"""
-        SELECT ks.kernel_name,
-               COUNT(*) as calls,
-               SUM(d.end - d.start) / 1000.0 as total_us,
-               AVG(d.end - d.start) / 1000.0 as avg_us,
-               d.grid_size_x
-        FROM {dispatch_table} d
-        JOIN {symbol_table} ks ON d.kernel_id = ks.id
-        WHERE ks.kernel_name LIKE '%mul_mat_vec_q%'
-        GROUP BY ks.kernel_name, d.grid_size_x
-        ORDER BY total_us DESC
-    """).fetchall()
+    try:
+        rows = db.execute(f"""
+            SELECT ks.kernel_name,
+                   COUNT(*) as calls,
+                   SUM(d.end - d.start) / 1000.0 as total_us,
+                   AVG(d.end - d.start) / 1000.0 as avg_us,
+                   d.grid_size_x
+            FROM {dispatch_table} d
+            JOIN {symbol_table} ks ON d.kernel_id = ks.id
+            WHERE ks.kernel_name LIKE '%mul_mat_vec_q%'
+            GROUP BY ks.kernel_name, d.grid_size_x
+            ORDER BY total_us DESC
+        """).fetchall()
+    except sqlite3.OperationalError:
+        # Malformed rocprof DB (e.g., missing the symbol table). Don't crash
+        # the whole sweep -- treat as "no timings available".
+        db.close()
+        return []
 
     timings = []
     for name, calls, total_us, avg_us, grid_x in rows:
@@ -177,10 +193,12 @@ def _run_bench_with_config(
 def _gen_config(nwarps: int, shapes: dict) -> str:
     """Generate a smithy JSON config with uniform nwarps for all shapes."""
     configs: dict[str, dict] = {}
+    skipped_types: set[str] = set()
 
     for (qt_name, n, k), count in shapes.items():
         type_idx = GGML_TYPE_MAP.get(qt_name)
         if type_idx is None:
+            skipped_types.add(qt_name)
             continue
 
         ni = bucket_index(n)
@@ -194,6 +212,16 @@ def _gen_config(nwarps: int, shapes: dict) -> str:
             "nwarps": nwarps,
             "rows_per_block": 1,
         }
+
+    if skipped_types:
+        # Loud warning so users know the GGML_TYPE_MAP needs an update when
+        # a model uses a quant kernel-anvil doesn't yet recognize. Silent
+        # drops here mean those layers never get tuned.
+        sys.stderr.write(
+            "kernel-anvil: warning: skipped untuned quant types "
+            f"(unknown to GGML_TYPE_MAP): {sorted(skipped_types)}. "
+            "Add them to kernel_anvil/codegen.py:GGML_TYPE_MAP.\n"
+        )
 
     return json.dumps({"gpu": "auto", "model": "sweep", "configs": configs}, indent=2)
 

--- a/kernel_anvil/mobile.py
+++ b/kernel_anvil/mobile.py
@@ -1,0 +1,160 @@
+"""Mobile GPU hardware constants and optimization heuristics.
+
+Supports Qualcomm Adreno 7xx/8xx and ARM Mali Valhall (G715/G720/G820).
+"""
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class MobileGpuSpec:
+    name: str
+    vendor: str  # "qualcomm" or "arm"
+    arch: str  # e.g., "adreno-7xx", "valhall-5th-gen"
+    wavefront_size: int
+    max_vgprs: int
+    lds_size_kb: int
+    shader_cores: int
+    memory_bandwidth_gbps: float
+    max_clock_mhz: int
+    fp16_tflops: float
+    vulkan_supported: bool = True
+    vulkan_min_version: str = "1.1"
+    notes: str = ""
+
+    @property
+    def lds_size_bytes(self) -> int:
+        return self.lds_size_kb * 1024
+
+    def max_vgpr_waves(self, vgpr_count: int) -> int:
+        """Max concurrent waves given VGPR usage.
+
+        Adreno allocates VGPRs per fiber (thread), Mali per warp.
+        Both architectures cap at a hardware-defined max waves.
+        """
+        if vgpr_count == 0:
+            return self._max_waves
+        return min(self._max_waves, self.max_vgprs // vgpr_count)
+
+    def max_lds_waves(self, lds_bytes: int, threads_per_wg: int) -> int:
+        """Max concurrent waves given LDS (shared memory) usage."""
+        if lds_bytes == 0:
+            return self._max_waves
+        wgs_per_core = self.lds_size_bytes // max(lds_bytes, 256)
+        waves_per_wg = (threads_per_wg + self.wavefront_size - 1) // self.wavefront_size
+        total_waves = wgs_per_core * waves_per_wg
+        return min(self._max_waves, total_waves)
+
+    def occupancy(self, vgpr_count: int, lds_bytes: int, threads_per_wg: int) -> tuple[float, str]:
+        """Returns (occupancy_pct, limiting_factor)."""
+        vgpr_w = self.max_vgpr_waves(vgpr_count)
+        lds_w = self.max_lds_waves(lds_bytes, threads_per_wg)
+        active = min(vgpr_w, lds_w)
+        pct = active / self._max_waves * 100
+        if vgpr_w < lds_w:
+            factor = "vgpr"
+        elif lds_w < vgpr_w:
+            factor = "lds"
+        else:
+            factor = "balanced"
+        return pct, factor
+
+    @property
+    def _max_waves(self) -> int:
+        """Hardware max concurrent waves per shader core.
+
+        Adreno 7xx/8xx: up to 16 waves per SP (shader processor).
+        Mali Valhall: up to 8 warps per execution engine.
+        """
+        if self.vendor == "qualcomm":
+            return 16
+        return 8  # ARM Mali
+
+
+# Qualcomm Adreno GPUs (Snapdragon SoCs)
+# Adreno uses 64-wide wavefronts (fibers), similar to AMD's wave64 mode.
+# VGPRs are allocated per-fiber with 256 registers available per SP.
+ADRENO_750 = MobileGpuSpec(
+    name="Adreno 750", vendor="qualcomm", arch="adreno-7xx",
+    wavefront_size=64, max_vgprs=256, lds_size_kb=32,
+    shader_cores=6, memory_bandwidth_gbps=77,
+    max_clock_mhz=903, fp16_tflops=4.6,
+    notes="Snapdragon 8 Gen 3",
+)
+
+ADRENO_740 = MobileGpuSpec(
+    name="Adreno 740", vendor="qualcomm", arch="adreno-7xx",
+    wavefront_size=64, max_vgprs=256, lds_size_kb=32,
+    shader_cores=5, memory_bandwidth_gbps=51.2,
+    max_clock_mhz=680, fp16_tflops=3.4,
+    notes="Snapdragon 8 Gen 2",
+)
+
+ADRENO_830 = MobileGpuSpec(
+    name="Adreno 830", vendor="qualcomm", arch="adreno-8xx",
+    wavefront_size=64, max_vgprs=256, lds_size_kb=32,
+    shader_cores=8, memory_bandwidth_gbps=102,
+    max_clock_mhz=1000, fp16_tflops=6.0,
+    notes="Snapdragon 8 Elite / 8 Gen 4",
+)
+
+# ARM Mali GPUs (Exynos, Dimensity, Tensor SoCs)
+# Mali Valhall uses 16-wide execution engines (warps).
+# 64 registers per warp, shared memory (tile buffer) is 16 KB per core.
+MALI_G720 = MobileGpuSpec(
+    name="Mali-G720", vendor="arm", arch="valhall-5th-gen",
+    wavefront_size=16, max_vgprs=64, lds_size_kb=16,
+    shader_cores=12, memory_bandwidth_gbps=51.2,
+    max_clock_mhz=1000, fp16_tflops=3.8,
+    notes="Dimensity 9300",
+)
+
+MALI_G715 = MobileGpuSpec(
+    name="Mali-G715", vendor="arm", arch="valhall-4th-gen",
+    wavefront_size=16, max_vgprs=64, lds_size_kb=16,
+    shader_cores=10, memory_bandwidth_gbps=44.8,
+    max_clock_mhz=850, fp16_tflops=2.7,
+    notes="Dimensity 9200 / Exynos 2300",
+)
+
+MALI_G820 = MobileGpuSpec(
+    name="Mali-G820", vendor="arm", arch="valhall-5th-gen",
+    wavefront_size=16, max_vgprs=64, lds_size_kb=16,
+    shader_cores=14, memory_bandwidth_gbps=68,
+    max_clock_mhz=1100, fp16_tflops=4.9,
+    notes="Dimensity 9400 / Exynos 2500",
+)
+
+MOBILE_GPU_SPECS = {
+    # Qualcomm Adreno
+    "adreno-750": ADRENO_750,
+    "adreno-740": ADRENO_740,
+    "adreno-830": ADRENO_830,
+    # ARM Mali
+    "mali-g720": MALI_G720,
+    "mali-g715": MALI_G715,
+    "mali-g820": MALI_G820,
+}
+
+# Aliases used in plan's test expectations
+MOBILE_GPUS = MOBILE_GPU_SPECS
+
+
+def get_mobile_gpu(name: str) -> Optional[MobileGpuSpec]:
+    """Look up a mobile GPU by its canonical name."""
+    return MOBILE_GPU_SPECS.get(name)
+
+
+# Mobile-specific optimization heuristics
+MOBILE_HEURISTICS = [
+    "Adreno 64-wide wavefronts match AMD wave64 -- same coalescing strategies apply",
+    "Mali 16-wide warps need 4x more workgroups for same occupancy as Adreno/AMD",
+    "Mobile LPDDR5 bandwidth (50-100 GB/s) is 5-10x less than desktop GDDR6 -- always bandwidth-bound",
+    "Shared memory (LDS) is 16-32 KB on mobile vs 64-96 KB desktop -- halve tile sizes",
+    "Thermal throttling is the dominant constraint -- sustained throughput << peak",
+    "Prefer FP16 compute: mobile GPUs have 2x FP16 rate vs FP32",
+    "Workgroup sizes of 64-128 balance occupancy vs register pressure on mobile",
+    "Avoid workgroup sizes > 256 on Mali (register file too small)",
+    "On Adreno, local_size_x should be a multiple of 64 (wavefront size)",
+    "On Mali, local_size_x should be a multiple of 16 (warp size)",
+]

--- a/kernel_anvil/model.py
+++ b/kernel_anvil/model.py
@@ -323,12 +323,17 @@ def optimize(
 
     # Resolve config for each unique shape
     shape_configs: dict[str, dict] = {}
+    newly_tuned: set[str] = set()  # shape_keys we actually tuned this run
     for (N, K), members in shapes.items():
         shape_key = f"({N}, {K})"
 
         if cached and shape_key in cached:
             config = cached[shape_key]
-        elif has_gpu and not cached:
+        elif has_gpu:
+            # Either no cache at all OR cache exists but is missing this
+            # shape. Tune it. (Previously: a partial cache miss silently
+            # fell through to defaults, locking new shapes added to a model
+            # post-cache out of optimization.)
             if verbose:
                 print(f"[kernel-anvil] Tuning shape {shape_key}...", end=" ", flush=True)
             t0 = time.monotonic()
@@ -337,8 +342,11 @@ def optimize(
             if verbose:
                 cfg_str = " ".join(f"{k}={v}" for k, v in sorted(config.items()))
                 print(f"done ({dt:.1f}s) -> {cfg_str}")
+            newly_tuned.add(shape_key)
         else:
-            # No GPU or no cache -- use defaults
+            # No GPU available -- use defaults. NOT a tuning result;
+            # MUST NOT be persisted to the cache (would poison future
+            # GPU-equipped runs into thinking these shapes were tuned).
             config = dict(_DEFAULT_CONFIG)
 
         shape_configs[shape_key] = config
@@ -356,8 +364,17 @@ def optimize(
     if verbose:
         print(f"[kernel-anvil] Replaced {replaced} nn.Linear layers with SmithyLinear")
 
-    # Save configs to cache
-    if not cached or _force_tune:
+    # Save configs to cache. Save when:
+    #   * no cache existed (write whatever we resolved -- preserves the
+    #     pre-existing UX where running optimize() on a CPU model still
+    #     produces a cache file), or
+    #   * --force_tune was requested, or
+    #   * a partial-miss run tuned at least one new shape.
+    # CRUCIALLY: do NOT save when there's already a cache and the only
+    # "fresh" entries this run are default-fallback configs from the no-GPU
+    # path. That would overwrite a partial cache with never-tuned defaults
+    # and poison future GPU-equipped runs into treating them as cache hits.
+    if _force_tune or not cached or newly_tuned:
         _save_configs(cache_file, shape_configs)
         if verbose:
             print(f"[kernel-anvil] Saved configs to {cache_file}")

--- a/kernel_anvil/rdna3.py
+++ b/kernel_anvil/rdna3.py
@@ -172,7 +172,12 @@ def detect_gpu() -> GpuSpec | None:
             if "strix point" in name or "gfx1151" in name:
                 return GFX1151
             # RDNA 3
-            if "7900 xtx" in name or "gfx1100" in name or "radeon graphics" in name:
+            # Note: "radeon graphics" alone is too generic -- ROCm reports
+            # several iGPUs (Phoenix, Strix Point) with that exact string,
+            # which would mis-classify them as a 7900 XTX (96 CUs, 960 GB/s)
+            # and produce wildly wrong occupancy/bandwidth heuristics.
+            # Only match on the unambiguous identifiers.
+            if "7900 xtx" in name or "gfx1100" in name:
                 return GFX1100
             if "7900 xt" in name and "xtx" not in name:
                 return GFX1101
@@ -181,7 +186,7 @@ def detect_gpu() -> GpuSpec | None:
             # RDNA 2
             if "6900" in name or "6800 xt" in name or "gfx1030" in name:
                 return GFX1030
-            if "6800" in name and "xt" not in name or "gfx1031" in name:
+            if ("6800" in name and "xt" not in name) or "gfx1031" in name:
                 return GFX1031
             if "6700" in name or "6650" in name or "6600" in name or "gfx1032" in name:
                 return GFX1032

--- a/kernel_anvil/vulkan_mobile_sweep.py
+++ b/kernel_anvil/vulkan_mobile_sweep.py
@@ -1,0 +1,216 @@
+"""Vulkan mobile sweep for kernel-anvil.
+
+Generates optimized Vulkan compute shader dispatch parameters for mobile GPUs
+(Adreno, Mali). Unlike the desktop vulkan_sweep.py which benchmarks live, this
+module produces configuration recommendations based on hardware profiles --
+actual on-device benchmarking requires an Android device.
+
+The approach:
+1. Select a mobile GPU profile (Adreno or Mali)
+2. Generate workgroup size / NUM_ROWS candidates respecting mobile constraints
+3. Estimate occupancy for each candidate
+4. Rank by predicted throughput (occupancy * bandwidth utilization)
+5. Emit optimal specialization constants for Vulkan pipeline creation
+
+Vulkan dequant shaders (e.g., dequant_turbo3_0.comp) use:
+  - local_size_x (workgroup size, must be multiple of wavefront/warp size)
+  - The shader operates on blocks of 32 elements with 256 threads default
+
+Mobile constraints vs desktop:
+  - LDS: 16-32 KB vs 64-96 KB (halve tile sizes)
+  - Bandwidth: 50-100 GB/s vs 500-960 GB/s (always bandwidth-bound)
+  - Thermals: sustained throughput << peak (prefer lower occupancy that sustains)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from kernel_anvil.mobile import MobileGpuSpec, MOBILE_GPU_SPECS, get_mobile_gpu
+
+
+@dataclass
+class MobileSweepConfig:
+    """A candidate Vulkan dispatch configuration for mobile."""
+    workgroup_size: int
+    num_rows: int
+    estimated_occupancy_pct: float
+    limiting_factor: str
+    bandwidth_utilization: float  # 0.0 - 1.0 estimate
+    score: float  # composite ranking score
+
+    @property
+    def label(self) -> str:
+        return f"wg={self.workgroup_size}_rows={self.num_rows}"
+
+
+@dataclass
+class MobileSweepResult:
+    """Result of a mobile Vulkan sweep."""
+    gpu: MobileGpuSpec
+    configs: list[MobileSweepConfig]
+    best: MobileSweepConfig
+    quant_type: str
+
+
+def _estimate_vgpr_usage(workgroup_size: int, num_rows: int) -> int:
+    """Estimate VGPR usage for a dequant kernel.
+
+    Dequant kernels are lightweight: a few index variables, the centroid LUT
+    (8 floats = 8 registers), norm, loop counter, output. Scale mildly with
+    num_rows since each row needs its own accumulation registers.
+    """
+    base = 16  # index vars, centroids, norm, output
+    per_row = 4  # accumulators per row
+    return base + per_row * num_rows
+
+
+def _estimate_lds_usage(workgroup_size: int, num_rows: int) -> int:
+    """Estimate LDS usage for a dequant kernel.
+
+    Dequant shaders typically don't use shared memory for the dequantization
+    itself (each thread reads its own block directly). LDS is only used if
+    there's a reduction step across the workgroup. Estimate conservatively.
+    """
+    if num_rows > 1:
+        # Multi-row may need a small reduction buffer
+        return workgroup_size * num_rows * 2  # FP16 = 2 bytes per element
+    return 0
+
+
+def _bandwidth_utilization(gpu: MobileGpuSpec, workgroup_size: int) -> float:
+    """Estimate how well the workgroup size utilizes memory bandwidth.
+
+    Optimal when workgroup_size is a multiple of the wavefront/warp size and
+    large enough to saturate memory channels, but not so large that it wastes
+    register file space.
+    """
+    wf = gpu.wavefront_size
+    # Perfect alignment bonus
+    aligned = 1.0 if workgroup_size % wf == 0 else 0.85
+
+    # Size sweet spot: enough waves for latency hiding without over-provisioning
+    waves_in_wg = workgroup_size / wf
+    if gpu.vendor == "qualcomm":
+        # Adreno sweet spot: 2-4 waves per workgroup
+        if 2 <= waves_in_wg <= 4:
+            size_factor = 1.0
+        elif waves_in_wg == 1:
+            size_factor = 0.75  # too few for latency hiding
+        else:
+            size_factor = 0.85  # diminishing returns
+    else:
+        # Mali sweet spot: 4-8 warps per workgroup (16-wide warps)
+        if 4 <= waves_in_wg <= 8:
+            size_factor = 1.0
+        elif waves_in_wg < 4:
+            size_factor = 0.7  # Mali needs more warps for occupancy
+        else:
+            size_factor = 0.85
+
+    return aligned * size_factor
+
+
+def generate_mobile_configs(
+    gpu: MobileGpuSpec,
+    quant_type: str = "turbo3_0",
+    max_configs: int = 20,
+) -> list[MobileSweepConfig]:
+    """Generate Vulkan dispatch configs ranked by predicted throughput.
+
+    Args:
+        gpu: Mobile GPU spec to target.
+        quant_type: Quantization type (affects block size assumptions).
+        max_configs: Maximum number of configs to return.
+
+    Returns:
+        List of configs sorted by score (best first).
+    """
+    wf = gpu.wavefront_size
+
+    # Candidate workgroup sizes: multiples of wavefront size
+    if gpu.vendor == "qualcomm":
+        wg_candidates = [64, 128, 256]  # Adreno: wave64
+    else:
+        wg_candidates = [16, 32, 64, 128]  # Mali: warp16
+
+    # NUM_ROWS candidates: how many output rows each workgroup processes
+    row_candidates = [1, 2, 4]
+
+    configs: list[MobileSweepConfig] = []
+    for wg_size in wg_candidates:
+        for num_rows in row_candidates:
+            # Skip configs that exceed hardware limits
+            vgpr_est = _estimate_vgpr_usage(wg_size, num_rows)
+            lds_est = _estimate_lds_usage(wg_size, num_rows)
+
+            if lds_est > gpu.lds_size_bytes:
+                continue
+
+            occ_pct, factor = gpu.occupancy(vgpr_est, lds_est, wg_size)
+            bw_util = _bandwidth_utilization(gpu, wg_size)
+
+            # Composite score: occupancy * bandwidth utilization
+            # Weight occupancy slightly less for mobile (thermal throttling
+            # means max occupancy isn't always best)
+            score = (occ_pct / 100.0) * 0.6 + bw_util * 0.4
+
+            configs.append(MobileSweepConfig(
+                workgroup_size=wg_size,
+                num_rows=num_rows,
+                estimated_occupancy_pct=occ_pct,
+                limiting_factor=factor,
+                bandwidth_utilization=bw_util,
+                score=score,
+            ))
+
+    configs.sort(key=lambda c: c.score, reverse=True)
+    return configs[:max_configs]
+
+
+def sweep_mobile(
+    gpu_name: str,
+    quant_type: str = "turbo3_0",
+    max_configs: int = 20,
+) -> MobileSweepResult | None:
+    """Run a mobile Vulkan sweep for a named GPU.
+
+    Args:
+        gpu_name: Canonical GPU name (e.g., "adreno-750", "mali-g720").
+        quant_type: Quantization type to optimize for.
+        max_configs: Maximum configs to evaluate.
+
+    Returns:
+        MobileSweepResult with ranked configs, or None if GPU not found.
+    """
+    gpu = get_mobile_gpu(gpu_name)
+    if gpu is None:
+        return None
+
+    configs = generate_mobile_configs(gpu, quant_type=quant_type, max_configs=max_configs)
+    if not configs:
+        return None
+
+    return MobileSweepResult(
+        gpu=gpu,
+        configs=configs,
+        best=configs[0],
+        quant_type=quant_type,
+    )
+
+
+def sweep_all_mobile(
+    quant_type: str = "turbo3_0",
+    max_configs: int = 5,
+) -> dict[str, MobileSweepResult]:
+    """Run sweep for all known mobile GPUs.
+
+    Returns:
+        Dict mapping GPU name to sweep result.
+    """
+    results = {}
+    for name in MOBILE_GPU_SPECS:
+        result = sweep_mobile(name, quant_type=quant_type, max_configs=max_configs)
+        if result is not None:
+            results[name] = result
+    return results

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,6 +4,12 @@ This patch adds runtime shape-specific MMVQ kernel configuration to llama.cpp.
 When kernel-anvil generates optimized configs for your model + GPU, this patch
 lets llama.cpp load them at startup.
 
+## Requirements
+
+`smithy-config.h` requires **C++17** (uses `std::atomic`, `std::shared_mutex`,
+`[[maybe_unused]]`, and capture lambdas). llama.cpp's CMake already targets
+C++17 by default, so no extra flags are needed for the upstream tree.
+
 ## Quick Apply
 
 ```bash

--- a/patches/smithy-config.h
+++ b/patches/smithy-config.h
@@ -14,9 +14,12 @@
 
 #pragma once
 
+#include <atomic>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <mutex>
+#include <shared_mutex>
 
 // GGML_TYPE_COUNT is defined in ggml.h when included inside a llama.cpp build.
 // Fallback for standalone compilation or static analysis.
@@ -47,21 +50,39 @@ static inline smithy_bucket smithy_get_bucket(int dim) {
 }
 
 static smithy_shape_config smithy_configs[GGML_TYPE_COUNT][SMITHY_NUM_BUCKETS][SMITHY_NUM_BUCKETS] = {};
-static bool smithy_configs_loaded  = false;
-static bool smithy_load_attempted  = false;
+static std::atomic<bool> smithy_configs_loaded{false};
+static std::atomic<bool> smithy_load_attempted{false};
 static char smithy_model_path[512] = {};
+// Serializes initialization and reset of smithy_configs[] / smithy_*_path /
+// load flags. llama.cpp's MMVQ dispatch path can be entered from multiple
+// host threads (multi-stream batching, draft+target during speculative
+// decoding). The mutex is shared:
+//   * smithy_lookup() (the hot per-dispatch read path) takes a SHARED lock
+//     so concurrent readers don't serialize on each other.
+//   * smithy_set_model() and smithy_try_load() take an EXCLUSIVE lock so
+//     the memset and cell-by-cell load complete before any reader observes
+//     the table -- otherwise readers could see a half-zeroed table or
+//     mid-update cells during a model swap.
+static std::shared_mutex smithy_load_mutex;
 
 // Call this when loading a model so smithy can find model-specific configs.
 // path: full path to the GGUF file (e.g., "/home/user/models/Qwen3-8B-Q4_K_M.gguf")
-static void smithy_set_model(const char * path) {
+[[maybe_unused]] static void smithy_set_model(const char * path) {
     if (!path) return;
+    // Exclusive lock: blocks all readers + other writers for the duration
+    // of the reset. Without this, a reader holding a shared lock could see
+    // smithy_configs[][][] mid-memset.
+    std::unique_lock<std::shared_mutex> guard(smithy_load_mutex);
     size_t len = strlen(path);
     if (len >= sizeof(smithy_model_path)) len = sizeof(smithy_model_path) - 1;
     memcpy(smithy_model_path, path, len);
     smithy_model_path[len] = '\0';
-    // Reset load state so the next lookup picks up the model-specific config
-    smithy_configs_loaded = false;
-    smithy_load_attempted = false;
+    // Clear load flags BEFORE memsetting the table. If the order were
+    // reversed, an early-returning reader (which is checking the loaded
+    // flag with acquire ordering before snatching its shared lock) could
+    // see loaded==true paired with a partially-zeroed table.
+    smithy_configs_loaded.store(false, std::memory_order_release);
+    smithy_load_attempted.store(false, std::memory_order_release);
     memset(smithy_configs, 0, sizeof(smithy_configs));
 }
 
@@ -81,70 +102,180 @@ static bool smithy_load_configs(const char * path) {
     buf[nread] = '\0';
 
     int loaded = 0;
-    const char * p = strstr(buf, "\"configs\"");
-    if (!p) { free(buf); return false; }
+    const char * configs_anchor = strstr(buf, "\"configs\"");
+    if (!configs_anchor) { free(buf); return false; }
 
-    while ((p = strchr(p, '"')) != NULL) {
-        p++;
-        int type_idx = -1;
-        if (*p >= '0' && *p <= '9') {
-            type_idx = atoi(p);
-            p = strchr(p, '{');
-            if (!p || type_idx < 0 || type_idx >= GGML_TYPE_COUNT) continue;
+    const char * buf_end = buf + size;
 
-            const char * type_end = NULL;
-            int depth = 1;
-            const char * scan = p + 1;
-            while (*scan && depth > 0) {
-                if (*scan == '{') depth++;
-                if (*scan == '}') depth--;
-                if (depth == 0) { type_end = scan; break; }
-                scan++;
+    // Skip a JSON string starting at `c` (which points at the opening '"').
+    // Advances past the closing '"', honoring backslash escapes. Returns the
+    // position immediately after the closing quote, or `end` if the string
+    // is unterminated. Critical for the depth scanners below: a '}' inside
+    // a JSON string (e.g. {"comment":"see }"}) must NOT be counted as an
+    // object close, otherwise siblings get silently dropped or
+    // re-attributed.
+    auto skip_string = [](const char * c, const char * end) -> const char * {
+        c++;  // past opening '"'
+        while (c < end && *c != '"') {
+            if (*c == '\\' && c + 1 < end) c += 2;
+            else c++;
+        }
+        if (c < end) c++;  // past closing '"'
+        return c;
+    };
+
+    // Find the matching '}' that closes the object opened at `open_brace`,
+    // honoring string-literal context so quoted braces don't confuse the
+    // depth count. Returns NULL if no balanced close is found before `end`.
+    auto find_matching_close = [&](const char * open_brace, const char * end) -> const char * {
+        if (!open_brace || *open_brace != '{') return NULL;
+        int depth = 1;
+        const char * c = open_brace + 1;
+        while (c < end && depth > 0) {
+            if (*c == '"') {
+                c = skip_string(c, end);
+                continue;
             }
-            if (!type_end) break;
+            if (*c == '{') depth++;
+            else if (*c == '}') {
+                depth--;
+                if (depth == 0) return c;
+            }
+            c++;
+        }
+        return NULL;
+    };
 
-            const char * entry = p;
-            while (entry < type_end) {
-                entry = strchr(entry, '"');
-                if (!entry || entry >= type_end) break;
-                entry++;
+    // Scans forward from `p` looking for the '{' that opens a JSON object
+    // VALUE associated with the most recently seen quoted key. Returns NULL
+    // if the value at this position is anything other than an object
+    // (string, number, null, true/false, etc.) -- this prevents malformed
+    // entries from letting strchr() blindly jump into the next sibling and
+    // mis-attribute its data. `end` bounds the scan.
+    auto find_object_value = [](const char * key_close_quote, const char * end) -> const char * {
+        if (!key_close_quote || key_close_quote >= end) return NULL;
+        const char * c = key_close_quote;
+        // skip the closing '"' if we're sitting on it
+        if (*c == '"') c++;
+        while (c < end && (*c == ' ' || *c == '\t' || *c == '\n' || *c == '\r')) c++;
+        if (c >= end || *c != ':') return NULL;
+        c++;
+        while (c < end && (*c == ' ' || *c == '\t' || *c == '\n' || *c == '\r')) c++;
+        if (c < end && *c == '{') return c;
+        return NULL;
+    };
 
-                int nb = -1, kb = -1;
-                if (sscanf(entry, "%d,%d", &nb, &kb) == 2 &&
-                    nb >= 0 && nb < SMITHY_NUM_BUCKETS &&
-                    kb >= 0 && kb < SMITHY_NUM_BUCKETS) {
+    // Bound the outer scan to the configs object's body. Without this the
+    // outer loop walks the entire remainder of the buffer and can pick up
+    // sibling top-level keys (e.g. {"configs": {...}, "telemetry":
+    // {"5": {"2,2": {...}}}}) as kernel configs.
+    const char * configs_brace = find_object_value(
+        configs_anchor + strlen("\"configs\""), buf_end);
+    if (!configs_brace) { free(buf); return false; }
+    const char * configs_end = find_matching_close(configs_brace, buf_end);
+    if (!configs_end) { free(buf); return false; }
 
-                    const char * nw_key  = strstr(entry, "\"nwarps\"");
-                    const char * rpb_key = strstr(entry, "\"rows_per_block\"");
-                    if (nw_key && nw_key < type_end && rpb_key && rpb_key < type_end) {
-                        int nw = 0, rpb = 0;
-                        const char * nw_val  = strchr(nw_key + 8, ':');
-                        const char * rpb_val = strchr(rpb_key + 16, ':');
-                        if (nw_val)  nw  = atoi(nw_val + 1);
-                        if (rpb_val) rpb = atoi(rpb_val + 1);
-                        if (nw > 0 && nw <= 32 && rpb > 0 && rpb <= 32) {
-                            smithy_configs[type_idx][nb][kb] = {nw, rpb};
-                            loaded++;
-                        }
+    const char * p = configs_brace;
+    while ((p = strchr(p, '"')) != NULL && p < configs_end) {
+        p++;
+        if (*p < '0' || *p > '9') continue;
+        int type_idx = atoi(p);
+
+        // Locate the closing quote of this digit key.
+        const char * key_close = strchr(p, '"');
+        if (!key_close || key_close >= configs_end) break;
+
+        // The value MUST be an object. If it's anything else (e.g. a
+        // string like "12":"oops"), skip the key and resume scanning --
+        // do NOT use strchr(p, '{') which would silently jump into the
+        // next sibling type's body and mis-attribute its cells under
+        // this type's index.
+        const char * type_brace = find_object_value(key_close, configs_end);
+        if (!type_brace) {
+            p = key_close + 1;
+            continue;
+        }
+
+        if (type_idx < 0 || type_idx >= GGML_TYPE_COUNT) {
+            // Skip past this type's body without parsing it.
+            p = type_brace;
+            continue;
+        }
+
+        const char * type_end = find_matching_close(type_brace, configs_end);
+        if (!type_end) break;
+
+        const char * entry = type_brace;
+        while (entry < type_end) {
+            entry = strchr(entry, '"');
+            if (!entry || entry >= type_end) break;
+            entry++;
+
+            int nb = -1, kb = -1;
+            if (sscanf(entry, "%d,%d", &nb, &kb) == 2 &&
+                nb >= 0 && nb < SMITHY_NUM_BUCKETS &&
+                kb >= 0 && kb < SMITHY_NUM_BUCKETS) {
+
+                // Locate the closing quote of THIS cell's bucket key.
+                const char * key_q = strchr(entry, '"');
+                if (!key_q || key_q >= type_end) break;
+
+                // The cell value MUST be an object. If it's a string,
+                // null, number, etc., skip the cell -- do NOT use
+                // strchr(entry, '{') which would jump into the next
+                // sibling cell and steal its data.
+                const char * cell_open = find_object_value(key_q, type_end);
+                if (!cell_open) {
+                    entry = key_q + 1;
+                    continue;
+                }
+
+                const char * cell_end = find_matching_close(cell_open, type_end);
+                if (!cell_end) break;
+
+                // nwarps / rows_per_block searches are bound by THIS
+                // cell's closing brace, not the type's.
+                const char * nw_key  = strstr(cell_open, "\"nwarps\"");
+                const char * rpb_key = strstr(cell_open, "\"rows_per_block\"");
+                if (nw_key && nw_key < cell_end && rpb_key && rpb_key < cell_end) {
+                    int nw = 0, rpb = 0;
+                    const char * nw_val  = strchr(nw_key + 8, ':');
+                    const char * rpb_val = strchr(rpb_key + 16, ':');
+                    if (nw_val  && nw_val  < cell_end) nw  = atoi(nw_val + 1);
+                    if (rpb_val && rpb_val < cell_end) rpb = atoi(rpb_val + 1);
+                    if (nw > 0 && nw <= 32 && rpb > 0 && rpb <= 32) {
+                        smithy_configs[type_idx][nb][kb] = {nw, rpb};
+                        loaded++;
                     }
                 }
-                entry++;
+                entry = cell_end + 1;
+                continue;
             }
-            p = type_end + 1;
+            entry++;
         }
+        p = type_end + 1;
     }
 
     free(buf);
-    smithy_configs_loaded = (loaded > 0);
-    if (smithy_configs_loaded) {
+    bool ok = (loaded > 0);
+    smithy_configs_loaded.store(ok, std::memory_order_release);
+    if (ok) {
         fprintf(stderr, "kernel-anvil: loaded %d shape configs from %s\n", loaded, path);
     }
-    return smithy_configs_loaded;
+    return ok;
 }
 
 static void smithy_try_load() {
-    if (smithy_configs_loaded || smithy_load_attempted) return;
-    smithy_load_attempted = true;
+    // Fast path: already loaded or already attempted (atomic acquire so any
+    // writes to smithy_configs[] are visible after we return).
+    if (smithy_configs_loaded.load(std::memory_order_acquire)) return;
+    if (smithy_load_attempted.load(std::memory_order_acquire)) return;
+
+    std::unique_lock<std::shared_mutex> guard(smithy_load_mutex);
+    // Re-check under lock (another thread may have loaded while we waited).
+    if (smithy_configs_loaded.load(std::memory_order_relaxed)) return;
+    if (smithy_load_attempted.load(std::memory_order_relaxed)) return;
+    smithy_load_attempted.store(true, std::memory_order_release);
 
     // Priority 1: SMITHY_CONFIG env var (explicit path)
     const char * env_path = getenv("SMITHY_CONFIG");
@@ -185,9 +316,15 @@ static void smithy_try_load() {
     smithy_load_configs(default_path);
 }
 
-static inline smithy_shape_config smithy_lookup(int type_idx, int nrows, int ncols) {
+[[maybe_unused]] static inline smithy_shape_config smithy_lookup(int type_idx, int nrows, int ncols) {
     smithy_try_load();
-    if (!smithy_configs_loaded || type_idx < 0 || type_idx >= GGML_TYPE_COUNT) {
+    // Shared lock: synchronizes with smithy_set_model() / smithy_try_load()
+    // exclusive locks so we never read smithy_configs[][][] mid-memset or
+    // mid-cell-write. Cheap when uncontended (atomic refcount), correct
+    // under contention (writers wait for readers to drain before reset).
+    std::shared_lock<std::shared_mutex> guard(smithy_load_mutex);
+    if (!smithy_configs_loaded.load(std::memory_order_acquire) ||
+        type_idx < 0 || type_idx >= GGML_TYPE_COUNT) {
         return {0, 0};
     }
     return smithy_configs[type_idx][smithy_get_bucket(nrows)][smithy_get_bucket(ncols)];

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=60.0"]
+# setuptools>=77 is required for PEP 639 SPDX-string licenses
+# (`license = "Apache-2.0"` below). Older setuptools (60..76) reject the
+# SPDX form with "project.license must be valid exactly by one definition".
+requires = ["setuptools>=77.0"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -1,5 +1,7 @@
 """Tests for the C header code generation module."""
 
+import sys
+
 import pytest
 
 from kernel_anvil.codegen import (
@@ -12,6 +14,8 @@ from kernel_anvil.codegen import (
     bucket_index,
     build_config_tables,
     generate_config_header,
+    generate_runtime_config,
+    merge_runtime_configs,
 )
 
 
@@ -253,3 +257,283 @@ class TestGGUFToCodegen:
         assert "GGML_TYPE_Q6_K" in header
         assert "#pragma once" in header
         assert f"smithy_configs[{GGML_TYPE_COUNT}]" in header
+
+
+# ---------------------------------------------------------------------------
+# Priority-aware merge (speculative decoding target+draft)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildConfigTablesWithPriority:
+    def test_no_priority_falls_back_to_last_seen_wins(self):
+        # Two shapes that share a bucket cell -- (LE_4096, LE_4096) for both.
+        configs = {
+            ("Q4_K", 3000, 3000): {"nwarps": 2, "rows_per_block": 1},
+            ("Q4_K", 4000, 4000): {"nwarps": 8, "rows_per_block": 4},
+        }
+        tables = build_config_tables(configs)
+        # Last inserted wins when no priorities are given.
+        assert tables["Q4_K"][2][2] == ShapeConfig(nwarps=8, rows_per_block=4)
+
+    def test_priority_picks_higher_speedup(self):
+        configs = {
+            ("Q4_K", 3000, 3000): {"nwarps": 2, "rows_per_block": 1},
+            ("Q4_K", 4000, 4000): {"nwarps": 8, "rows_per_block": 4},
+        }
+        priorities = {
+            ("Q4_K", 3000, 3000): 1.95,  # better speedup -- should win
+            ("Q4_K", 4000, 4000): 1.10,
+        }
+        tables = build_config_tables(configs, priorities=priorities)
+        assert tables["Q4_K"][2][2] == ShapeConfig(nwarps=2, rows_per_block=1)
+
+    def test_priority_missing_treated_as_minus_inf(self):
+        # Only the first shape has a recorded speedup; second is "unknown" and
+        # MUST NOT win on the bucket cell.
+        configs = {
+            ("Q4_K", 3000, 3000): {"nwarps": 2, "rows_per_block": 1},
+            ("Q4_K", 4000, 4000): {"nwarps": 8, "rows_per_block": 4},
+        }
+        priorities = {("Q4_K", 3000, 3000): 1.30}
+        tables = build_config_tables(configs, priorities=priorities)
+        assert tables["Q4_K"][2][2] == ShapeConfig(nwarps=2, rows_per_block=1)
+
+    def test_priority_does_not_affect_distinct_buckets(self):
+        # Target-shaped (LE_16384) and draft-shaped (LE_1024) land in different
+        # cells; both should survive regardless of priorities.
+        configs = {
+            ("Q4_K", 5120, 5120): {"nwarps": 8, "rows_per_block": 2},   # target
+            ("Q4_K", 1024, 1024): {"nwarps": 2, "rows_per_block": 1},   # draft
+        }
+        priorities = {
+            ("Q4_K", 5120, 5120): 1.80,
+            ("Q4_K", 1024, 1024): 1.20,
+        }
+        tables = build_config_tables(configs, priorities=priorities)
+        # 5120 -> bucket 3 (LE_16384), 1024 -> bucket 1 (LE_1024)
+        assert tables["Q4_K"][3][3] == ShapeConfig(nwarps=8, rows_per_block=2)
+        assert tables["Q4_K"][1][1] == ShapeConfig(nwarps=2, rows_per_block=1)
+
+    def test_priority_threads_through_runtime_config(self):
+        import json
+        configs = {
+            ("Q4_K", 3000, 3000): {"nwarps": 2, "rows_per_block": 1},
+            ("Q4_K", 4000, 4000): {"nwarps": 8, "rows_per_block": 4},
+        }
+        priorities = {
+            ("Q4_K", 3000, 3000): 1.95,
+            ("Q4_K", 4000, 4000): 1.10,
+        }
+        out = json.loads(generate_runtime_config(configs, priorities=priorities))
+        type_idx = str(GGML_TYPE_MAP["Q4_K"])
+        assert out["configs"][type_idx]["2,2"] == {"nwarps": 2, "rows_per_block": 1}
+
+
+# ---------------------------------------------------------------------------
+# merge_runtime_configs (speculative decoding via separate JSONs)
+# ---------------------------------------------------------------------------
+
+
+class TestMergeRuntimeConfigs:
+    def _payload(self, model, cells_by_type):
+        return {
+            "gpu": "gfx1100",
+            "model": model,
+            "configs": {
+                str(t): {k: dict(v) for k, v in cells.items()}
+                for t, cells in cells_by_type.items()
+            },
+        }
+
+    def test_empty_inputs_returns_empty_payload(self):
+        merged = merge_runtime_configs([])
+        assert merged["configs"] == {}
+
+    def test_disjoint_cells_are_unioned(self):
+        a = self._payload("target", {12: {"3,3": {"nwarps": 8, "rows_per_block": 2}}})
+        b = self._payload("draft",  {12: {"1,1": {"nwarps": 2, "rows_per_block": 1}}})
+        merged = merge_runtime_configs([a, b])
+        cells = merged["configs"]["12"]
+        assert cells["3,3"] == {"nwarps": 8, "rows_per_block": 2}
+        assert cells["1,1"] == {"nwarps": 2, "rows_per_block": 1}
+
+    def test_first_seen_wins_on_conflict(self):
+        a = self._payload("target", {12: {"2,2": {"nwarps": 8, "rows_per_block": 4}}})
+        b = self._payload("draft",  {12: {"2,2": {"nwarps": 2, "rows_per_block": 1}}})
+        merged = merge_runtime_configs([a, b])
+        # First payload (target) wins.
+        assert merged["configs"]["12"]["2,2"] == {"nwarps": 8, "rows_per_block": 4}
+
+    def test_distinct_quant_types_coexist(self):
+        a = self._payload("target", {12: {"2,2": {"nwarps": 4, "rows_per_block": 1}}})
+        b = self._payload("draft",  {14: {"1,1": {"nwarps": 2, "rows_per_block": 2}}})
+        merged = merge_runtime_configs([a, b])
+        assert "12" in merged["configs"]
+        assert "14" in merged["configs"]
+
+    def test_default_model_name_joins_with_plus(self):
+        a = self._payload("Qwen3-8B", {12: {"2,2": {"nwarps": 4, "rows_per_block": 1}}})
+        b = self._payload("Qwen3-0.6B", {12: {"1,1": {"nwarps": 2, "rows_per_block": 1}}})
+        merged = merge_runtime_configs([a, b])
+        assert merged["model"] == "Qwen3-8B+Qwen3-0.6B"
+
+    def test_explicit_overrides(self):
+        a = self._payload("target", {12: {"2,2": {"nwarps": 4, "rows_per_block": 1}}})
+        merged = merge_runtime_configs([a], gpu_name="gfx1201", model_name="custom")
+        assert merged["gpu"] == "gfx1201"
+        assert merged["model"] == "custom"
+
+    def test_does_not_mutate_inputs(self):
+        a = self._payload("target", {12: {"2,2": {"nwarps": 8, "rows_per_block": 4}}})
+        b = self._payload("draft",  {12: {"2,2": {"nwarps": 2, "rows_per_block": 1}}})
+        a_snapshot = {"gpu": a["gpu"], "model": a["model"], "configs": {k: dict(v) for k, v in a["configs"].items()}}
+        merge_runtime_configs([a, b])
+        assert a["configs"]["12"]["2,2"] == a_snapshot["configs"]["12"]["2,2"]
+
+
+# ---------------------------------------------------------------------------
+# CLI: merge-configs subcommand end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestCLIMergeConfigs:
+    def test_merge_configs_writes_output(self, tmp_path, monkeypatch):
+        import json
+        from kernel_anvil import cli
+
+        a = tmp_path / "target.json"
+        b = tmp_path / "draft.json"
+        a.write_text(json.dumps({
+            "gpu": "gfx1100", "model": "target",
+            "configs": {"12": {"3,3": {"nwarps": 8, "rows_per_block": 2}}},
+        }))
+        b.write_text(json.dumps({
+            "gpu": "gfx1100", "model": "draft",
+            "configs": {"12": {"1,1": {"nwarps": 2, "rows_per_block": 1}}},
+        }))
+        out = tmp_path / "merged.json"
+
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "merge-configs", str(a), str(b), "-o", str(out),
+        ])
+        cli.main()
+
+        assert out.exists()
+        merged = json.loads(out.read_text())
+        cells = merged["configs"]["12"]
+        assert cells["3,3"] == {"nwarps": 8, "rows_per_block": 2}
+        assert cells["1,1"] == {"nwarps": 2, "rows_per_block": 1}
+        assert merged["model"] == "target+draft"
+
+    def test_merge_configs_missing_input_exits_clean(self, tmp_path, monkeypatch, capsys):
+        from kernel_anvil import cli
+
+        out = tmp_path / "merged.json"
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "merge-configs",
+            str(tmp_path / "does-not-exist.json"),
+            "-o", str(out),
+        ])
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 1
+
+    def test_merge_configs_invalid_json_exits_clean(self, tmp_path, monkeypatch):
+        from kernel_anvil import cli
+
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not valid json")
+        out = tmp_path / "merged.json"
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "merge-configs", str(bad), "-o", str(out),
+        ])
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 1
+        assert not out.exists()
+
+    def test_merge_configs_atomic_write(self, tmp_path, monkeypatch):
+        # No partial / temp files left in the parent dir after a successful merge.
+        import json
+        from kernel_anvil import cli
+
+        a = tmp_path / "a.json"
+        a.write_text(json.dumps({
+            "gpu": "gfx1100", "model": "x",
+            "configs": {"12": {"2,2": {"nwarps": 4, "rows_per_block": 1}}},
+        }))
+        out = tmp_path / "merged.json"
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "merge-configs", str(a), "-o", str(out),
+        ])
+        cli.main()
+        leftover = [p.name for p in tmp_path.iterdir() if p.name.endswith(".json.tmp")]
+        assert leftover == [], f"atomic write left tempfiles behind: {leftover}"
+
+
+# ---------------------------------------------------------------------------
+# Defensive merge_runtime_configs: malformed payloads must not crash
+# ---------------------------------------------------------------------------
+
+
+class TestMergeRuntimeConfigsDefensive:
+    def test_skips_non_dict_payload(self):
+        merged = merge_runtime_configs([None, "not a dict", 42])
+        assert merged["configs"] == {}
+
+    def test_skips_non_dict_configs_section(self):
+        bad = {"gpu": "x", "model": "y", "configs": "not a dict"}
+        merged = merge_runtime_configs([bad])
+        assert merged["configs"] == {}
+
+    def test_skips_null_cells_section(self):
+        bad = {"gpu": "x", "model": "y", "configs": {"12": None}}
+        merged = merge_runtime_configs([bad])
+        # Type bucket may be created empty or skipped; neither should crash.
+        assert merged["configs"].get("12", {}) == {}
+
+    def test_skips_string_cells_section(self):
+        bad = {"gpu": "x", "model": "y", "configs": {"12": "evil"}}
+        merged = merge_runtime_configs([bad])
+        assert merged["configs"].get("12", {}) == {}
+
+    def test_skips_non_dict_cell_cfg(self):
+        bad = {"gpu": "x", "model": "y", "configs": {"12": {"1,1": "bad"}}}
+        merged = merge_runtime_configs([bad])
+        # Cell skipped; type bucket exists but is empty.
+        assert merged["configs"].get("12", {}) == {}
+
+    def test_null_model_field_does_not_crash_join(self):
+        a = {"gpu": "x", "model": None, "configs": {}}
+        b = {"gpu": "x", "model": "real", "configs": {}}
+        merged = merge_runtime_configs([a, b])
+        # None coerces to 'unknown', then joined.
+        assert "+" in merged["model"]
+
+    def test_well_formed_payload_after_malformed_still_merges(self):
+        good = {"gpu": "x", "model": "good",
+                "configs": {"12": {"2,2": {"nwarps": 4, "rows_per_block": 1}}}}
+        merged = merge_runtime_configs([None, "junk", good])
+        assert merged["configs"]["12"]["2,2"] == {"nwarps": 4, "rows_per_block": 1}
+
+
+# ---------------------------------------------------------------------------
+# NaN priority handling in build_config_tables
+# ---------------------------------------------------------------------------
+
+
+class TestNaNPriority:
+    def test_nan_priority_does_not_silently_overwrite(self):
+        # Without the NaN guard, a NaN priority always "wins" because
+        # real_val <= nan is False, letting later entries overwrite.
+        configs = {
+            ("Q4_K", 3000, 3000): {"nwarps": 2, "rows_per_block": 1},
+            ("Q4_K", 4000, 4000): {"nwarps": 8, "rows_per_block": 4},
+        }
+        priorities = {
+            ("Q4_K", 3000, 3000): float("nan"),  # malformed
+            ("Q4_K", 4000, 4000): 1.10,           # real
+        }
+        tables = build_config_tables(configs, priorities=priorities)
+        # Real priority must win over NaN in the shared bucket.
+        assert tables["Q4_K"][2][2] == ShapeConfig(nwarps=8, rows_per_block=4)

--- a/tests/test_gguf.py
+++ b/tests/test_gguf.py
@@ -1,6 +1,7 @@
 """Tests for the GGUF parser module."""
 
 import io
+import os
 import sys
 from pathlib import Path
 
@@ -8,7 +9,15 @@ import pytest
 
 from kernel_anvil.gguf import ModelProfile, TensorInfo, parse_gguf, print_model_summary
 
-QWEN3_PATH = Path.home() / "Models" / "Qwen3-8B-Q4_K_M.gguf"
+# Override with KERNEL_ANVIL_TEST_GGUF=/path/to/any.gguf to point the
+# integration tests at a different model. Tests skip cleanly when the
+# file is absent.
+QWEN3_PATH = Path(
+    os.environ.get(
+        "KERNEL_ANVIL_TEST_GGUF",
+        str(Path.home() / "Models" / "Qwen3-8B" / "Qwen3-8B-Q4_K_M.gguf"),
+    )
+)
 _skip_no_model = pytest.mark.skipif(
     not QWEN3_PATH.exists(), reason=f"GGUF file not found: {QWEN3_PATH}"
 )

--- a/tests/test_gguf_optimize.py
+++ b/tests/test_gguf_optimize.py
@@ -1,5 +1,6 @@
 """Tests for the smithy gguf-optimize CLI command."""
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -11,7 +12,14 @@ import torch
 from kernel_anvil.cli import main, _make_runner, _tune_shape_cli
 
 PROJ_ROOT = Path(__file__).parent.parent
-QWEN3_PATH = Path.home() / "Models" / "Qwen3-8B-Q4_K_M.gguf"
+# Override with KERNEL_ANVIL_TEST_GGUF=/path/to/any.gguf to point the
+# integration tests at a different model. Tests skip cleanly when absent.
+QWEN3_PATH = Path(
+    os.environ.get(
+        "KERNEL_ANVIL_TEST_GGUF",
+        str(Path.home() / "Models" / "Qwen3-8B" / "Qwen3-8B-Q4_K_M.gguf"),
+    )
+)
 HAS_GPU = torch.cuda.is_available()
 
 _skip_no_gpu = pytest.mark.skipif(not HAS_GPU, reason="No GPU available")

--- a/tests/test_gguf_optimize.py
+++ b/tests/test_gguf_optimize.py
@@ -164,35 +164,39 @@ class TestGGUFOptimizeEndToEnd:
 class TestGGUFOptimizeMocked:
     """Test the command flow with mocked tuning (no GPU needed)."""
 
-    def test_no_gpu_exits_gracefully(self, tmp_path):
-        """With no GPU, command should print error and exit 1."""
-        # Create a minimal valid GGUF-like file (won't be parsed if GPU check fails first)
+    def test_no_gpu_falls_back_to_no_bench(self, tmp_path, monkeypatch, capsys):
+        """When torch.cuda.is_available() returns False, gguf-optimize must
+        fall back to --no-bench mode (heuristic configs) instead of failing.
+        Prior to this rewrite, this test only checked --help and didn't
+        actually exercise the no-GPU code path at cli.py:422-428."""
+        from kernel_anvil.gguf import ModelProfile, TensorInfo
+        from kernel_anvil.cli import cmd_gguf_optimize
+        import argparse
+
+        monkeypatch.setenv("HOME", str(tmp_path))  # sandbox cache dir
         fake_gguf = tmp_path / "fake.gguf"
         fake_gguf.write_bytes(b"GGUF" + b"\x00" * 100)
-
-        with patch("kernel_anvil.cli.torch") as mock_torch:
-            mock_torch.cuda.is_available.return_value = False
-            result = subprocess.run(
-                [sys.executable, "-c", f"""
-import sys
-from unittest.mock import patch, MagicMock
-mock_torch = MagicMock()
-mock_torch.cuda.is_available.return_value = False
-mock_torch.device = MagicMock
-with patch.dict('sys.modules', {{'torch': mock_torch, 'torch.nn': MagicMock(), 'torch.nn.functional': MagicMock()}}):
-    # This approach is fragile; use subprocess with env instead
-    pass
-"""],
-                capture_output=True, text=True, timeout=10,
-            )
-        # The mocking approach via subprocess is unreliable; test directly
-        # Just verify the code path exists by checking help works
-        result2 = subprocess.run(
-            [sys.executable, "-m", "kernel_anvil.cli", "gguf-optimize", "--help"],
-            capture_output=True, text=True, timeout=10,
+        profile = ModelProfile(
+            name="NoGpuTest",
+            architecture="test",
+            tensors=[TensorInfo("w", (64, 64), "Q4_K", 4096)],
+            unique_shapes={("Q4_K", 64, 64): 1},
         )
-        assert result2.returncode == 0
-        assert "gguf" in result2.stdout
+        args = argparse.Namespace(
+            gguf=str(fake_gguf), output="smithy-config.h",
+            max_configs=3, warmup=1, runs=2,
+            no_bench=False, draft=None,
+        )
+
+        with patch("kernel_anvil.cli.parse_gguf", return_value=profile), \
+             patch("torch.cuda.is_available", return_value=False):
+            cmd_gguf_optimize(args)
+
+        out = capsys.readouterr().out
+        assert "GPU not detected" in out  # the fallback branch was taken
+        # And the cache file was still written (heuristic configs).
+        cache = tmp_path / ".cache" / "smithy" / "fake.json"
+        assert cache.exists()
 
     def test_nonexistent_file_exits(self):
         result = subprocess.run(
@@ -210,6 +214,12 @@ with patch.dict('sys.modules', {{'torch': mock_torch, 'torch.nn': MagicMock(), '
 @_skip_no_gpu
 class TestGGUFOptimizeSmallShape:
     """Test the pipeline with a synthetic small model profile."""
+
+    @pytest.fixture(autouse=True)
+    def _sandbox_home(self, tmp_path, monkeypatch):
+        """Redirect ~/.cache/smithy/ writes to tmp_path so this test does
+        not clobber the user's real config cache."""
+        monkeypatch.setenv("HOME", str(tmp_path))
 
     def test_pipeline_with_mock_gguf(self, tmp_path):
         """Mock parse_gguf to return small shapes, then run the real pipeline."""
@@ -236,12 +246,17 @@ class TestGGUFOptimizeSmallShape:
         with patch("kernel_anvil.cli.parse_gguf", return_value=small_profile):
             from kernel_anvil.cli import cmd_gguf_optimize
             import argparse
+            # Match what argparse actually produces: include all flags so
+            # this test fails loudly if direct attribute access ever
+            # replaces the getattr() defensive defaults in cmd_gguf_optimize.
             args = argparse.Namespace(
                 gguf=str(fake_gguf),
                 output=str(output),
                 max_configs=3,
                 warmup=1,
                 runs=2,
+                no_bench=False,
+                draft=None,
             )
 
             cmd_gguf_optimize(args)
@@ -251,3 +266,174 @@ class TestGGUFOptimizeSmallShape:
         assert "#pragma once" in header
         assert "GGML_TYPE_Q4_K" in header
         assert "TestModel-Tiny" in header
+
+
+# ---------------------------------------------------------------------------
+# --draft (speculative decoding) flow
+# ---------------------------------------------------------------------------
+
+
+class TestGGUFOptimizeDraft:
+    def _make_profile(self, name, shapes):
+        from kernel_anvil.gguf import ModelProfile, TensorInfo
+        return ModelProfile(
+            name=name,
+            architecture="test",
+            tensors=[TensorInfo(f"w{i}", (n, k), qt, n * k)
+                     for i, (qt, n, k) in enumerate(shapes)],
+            unique_shapes={s: 1 for s in shapes},
+        )
+
+    @pytest.fixture(autouse=True)
+    def _sandbox_home(self, tmp_path, monkeypatch):
+        """Redirect ~/.cache/smithy/ writes to tmp_path so tests don't
+        clobber the user's real cache. cmd_gguf_optimize uses
+        Path.home() which honors $HOME on POSIX."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+
+    def _run(self, tmp_path, target_shapes, draft_shapes_list):
+        """Invoke cmd_gguf_optimize with mocked GGUFs and --no-bench."""
+        import argparse
+
+        target_gguf = tmp_path / "target.gguf"
+        target_gguf.write_bytes(b"GGUF" + b"\x00" * 100)
+        target_profile = self._make_profile("Target-Model", target_shapes)
+
+        draft_paths = []
+        draft_profiles = []
+        for i, ds in enumerate(draft_shapes_list, start=1):
+            dp = tmp_path / f"draft{i}.gguf"
+            dp.write_bytes(b"GGUF" + b"\x00" * 100)
+            draft_paths.append(str(dp))
+            draft_profiles.append(self._make_profile(f"Draft-{i}", ds))
+
+        # parse_gguf returns target first, then each draft in order.
+        parse_returns = [target_profile, *draft_profiles]
+
+        # Force --no-bench so we don't need a GPU.
+        args = argparse.Namespace(
+            gguf=str(target_gguf),
+            output="smithy-config.h",
+            max_configs=3,
+            warmup=1,
+            runs=2,
+            no_bench=True,
+            draft=draft_paths or None,
+        )
+
+        from kernel_anvil.cli import cmd_gguf_optimize
+        with patch("kernel_anvil.cli.parse_gguf", side_effect=parse_returns):
+            cmd_gguf_optimize(args)
+
+        # Reads from sandboxed HOME (set by _sandbox_home fixture).
+        cache_path = Path.home() / ".cache" / "smithy" / f"{Path(target_gguf).stem}.json"
+        return cache_path
+
+    def test_draft_writes_merged_model_name(self, tmp_path, capsys):
+        cache = self._run(
+            tmp_path,
+            target_shapes=[("Q4_K", 4096, 4096)],
+            draft_shapes_list=[[("Q4_K", 1024, 1024)]],
+        )
+        import json
+        data = json.loads(cache.read_text())
+        assert data["model"] == "Target-Model+Draft-1"
+        # Sandboxed cache must be inside tmp_path -- never at the real ~.
+        assert str(tmp_path) in str(cache)
+
+    def test_draft_run_hint_includes_md_flag(self, tmp_path, capsys):
+        # The "Run:" line printed at the end MUST include -md <draft_path>
+        # when --draft is used, otherwise users copy-pasting the hint will
+        # silently disable speculative decoding.
+        self._run(
+            tmp_path,
+            target_shapes=[("Q4_K", 4096, 4096)],
+            draft_shapes_list=[[("Q4_K", 1024, 1024)]],
+        )
+        out = capsys.readouterr().out
+        assert "-md" in out
+        assert "draft1.gguf" in out
+        # Should also use SMITHY_CONFIG (explicit path) rather than
+        # SMITHY_MODEL when --draft is used.
+        assert "SMITHY_CONFIG=" in out
+
+    def test_no_draft_hint_omits_md(self, tmp_path, capsys):
+        # Without --draft, the hint must NOT contain -md (regression check).
+        self._run(
+            tmp_path,
+            target_shapes=[("Q4_K", 4096, 4096)],
+            draft_shapes_list=[],
+        )
+        out = capsys.readouterr().out
+        assert "-md" not in out
+
+    def test_multiple_drafts_produce_labeled_results(self, tmp_path):
+        cache = self._run(
+            tmp_path,
+            target_shapes=[("Q4_K", 4096, 4096)],
+            draft_shapes_list=[
+                [("Q4_K", 1024, 1024)],
+                [("Q4_K", 2048, 2048)],
+            ],
+        )
+        import json
+        data = json.loads(cache.read_text())
+        assert "Draft-1" in data["model"]
+        assert "Draft-2" in data["model"]
+
+    def test_draft_recovers_after_target_profile_failure(self, tmp_path):
+        # If profiling raises for shape (qt, N, K) on the target, the slot
+        # MUST remain empty so a draft model with the same shape gets a
+        # chance to profile it. (Pre-fix, the target's exception path wrote
+        # a fallback config that the draft loop would then skip.)
+        import argparse
+
+        target_gguf = tmp_path / "target.gguf"
+        target_gguf.write_bytes(b"GGUF" + b"\x00" * 100)
+        draft_gguf = tmp_path / "draft.gguf"
+        draft_gguf.write_bytes(b"GGUF" + b"\x00" * 100)
+
+        shape = ("Q4_K", 4096, 4096)
+        target_profile = self._make_profile("T", [shape])
+        draft_profile = self._make_profile("D", [shape])
+
+        call_count = {"n": 0}
+        def flaky_tune(*, N, K, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("simulated transient failure on target")
+            return ({"nwarps": 8, "rows_per_block": 4}, 100.0, 1.5)
+
+        args = argparse.Namespace(
+            gguf=str(target_gguf),
+            output="smithy-config.h",
+            max_configs=3,
+            warmup=1,
+            runs=2,
+            no_bench=False,  # bench mode so _tune_shape_cli is invoked
+            draft=[str(draft_gguf)],
+        )
+
+        from kernel_anvil.cli import cmd_gguf_optimize
+        with patch("kernel_anvil.cli.parse_gguf", side_effect=[target_profile, draft_profile]), \
+             patch("kernel_anvil.cli._tune_shape_cli", side_effect=flaky_tune), \
+             patch("kernel_anvil.cli._get_gpu_spec") as gs, \
+             patch("torch.cuda.is_available", return_value=True), \
+             patch("torch.device"):
+            from kernel_anvil.rdna3 import GFX1100
+            gs.return_value = GFX1100
+            cmd_gguf_optimize(args)
+
+        # Must have called _tune_shape_cli twice: once for target (failed)
+        # then once for draft (recovered). If the target's failure had
+        # poisoned the slot, the draft would have skipped it and call_count
+        # would still be 1.
+        assert call_count["n"] == 2
+
+        cache = Path.home() / ".cache" / "smithy" / f"{Path(target_gguf).stem}.json"
+        import json
+        data = json.loads(cache.read_text())
+        type_idx = "12"  # Q4_K
+        # Bucket (3, 3) for (4096, 4096): N=4096 -> bucket 2, K=4096 -> bucket 2.
+        cells = data["configs"].get(type_idx, {})
+        assert cells.get("2,2") == {"nwarps": 8, "rows_per_block": 4}

--- a/tests/test_llama_sweep.py
+++ b/tests/test_llama_sweep.py
@@ -1,0 +1,80 @@
+"""Tests for llama_sweep helpers focused on edge-case correctness."""
+
+import json
+import sqlite3
+
+import pytest
+
+from kernel_anvil.llama_sweep import _gen_config, _parse_rocprof_db
+
+
+class TestGenConfigUnknownQuants:
+    def test_unknown_quant_emits_warning(self, capsys):
+        # Known quant + an invented one. The known quant should still land in
+        # configs; the unknown one is dropped, but a warning must be emitted
+        # so the user knows a layer of their model didn't get tuned.
+        shapes = {
+            ("Q4_K", 4096, 4096): 1,
+            ("INVENTED_QUANT", 4096, 4096): 1,
+        }
+        out = _gen_config(nwarps=4, shapes=shapes)
+        captured = capsys.readouterr()
+
+        configs = json.loads(out)["configs"]
+        # Q4_K (type_idx 12) lands; INVENTED_QUANT does not.
+        assert "12" in configs
+        assert all("INVENTED" not in v for v in configs)
+
+        assert "skipped untuned quant types" in captured.err
+        assert "INVENTED_QUANT" in captured.err
+
+    def test_no_warning_when_all_known(self, capsys):
+        shapes = {("Q4_K", 4096, 4096): 1}
+        _gen_config(nwarps=4, shapes=shapes)
+        captured = capsys.readouterr()
+        assert "skipped" not in captured.err
+
+
+class TestParseRocprofDB:
+    def _make_db(self, tmp_path, table_names: list[str]) -> str:
+        """Build a tiny SQLite DB with the given table names. No data needed
+        for the tests below -- we're checking that the LIKE filter correctly
+        narrows to literal-underscore prefixes only."""
+        db_path = tmp_path / "rocprof.db"
+        db = sqlite3.connect(db_path)
+        for name in table_names:
+            # Identifiers may contain weird chars; quote with brackets.
+            db.execute(f'CREATE TABLE "{name}" (id INTEGER)')
+        db.commit()
+        db.close()
+        return str(db_path)
+
+    def test_like_pattern_excludes_non_underscore_match(self, tmp_path):
+        # 'rocpd_kernel_dispatchABC' would match the unescaped LIKE pattern
+        # 'rocpd_kernel_dispatch_%' (because '_' is a single-char wildcard).
+        # The fix escapes the underscores. Check that this table is NOT
+        # selected as the dispatch table.
+        db_path = self._make_db(tmp_path, [
+            "rocpd_kernel_dispatchABC",  # ambiguous; SHOULD be skipped
+        ])
+        timings = _parse_rocprof_db(db_path)
+        # No matching dispatch table -> empty result. Crucially, no crash.
+        assert timings == []
+
+    def test_handles_missing_symbol_table_gracefully(self, tmp_path):
+        # The dispatch table exists with a literal-underscore prefix, but
+        # the matching symbol table is absent. Pre-fix, the SELECT raised
+        # OperationalError uncaught. Now it should return [].
+        db_path = self._make_db(tmp_path, [
+            "rocpd_kernel_dispatch_abc123",
+            # Note: no rocpd_info_kernel_symbol_abc123 table.
+        ])
+        timings = _parse_rocprof_db(db_path)
+        assert timings == []
+
+    def test_no_matching_table_returns_empty(self, tmp_path):
+        db_path = self._make_db(tmp_path, [
+            "unrelated_table",
+        ])
+        timings = _parse_rocprof_db(db_path)
+        assert timings == []

--- a/tests/test_mobile.py
+++ b/tests/test_mobile.py
@@ -1,0 +1,189 @@
+"""Tests for mobile GPU hardware constants and occupancy calculations."""
+import pytest
+
+from kernel_anvil.mobile import (
+    ADRENO_750,
+    ADRENO_740,
+    ADRENO_830,
+    MALI_G720,
+    MALI_G715,
+    MALI_G820,
+    MOBILE_GPU_SPECS,
+    MOBILE_GPUS,
+    MobileGpuSpec,
+    get_mobile_gpu,
+)
+
+
+# --- Lookup tests ---
+
+def test_get_adreno_750():
+    gpu = get_mobile_gpu("adreno-750")
+    assert gpu is not None
+    assert gpu is ADRENO_750
+    assert gpu.vendor == "qualcomm"
+    assert gpu.wavefront_size == 64
+
+
+def test_get_mali_g720():
+    gpu = get_mobile_gpu("mali-g720")
+    assert gpu is not None
+    assert gpu is MALI_G720
+    assert gpu.vendor == "arm"
+    assert gpu.wavefront_size == 16
+
+
+def test_get_unknown_gpu():
+    gpu = get_mobile_gpu("nonexistent-gpu")
+    assert gpu is None
+
+
+def test_mobile_gpus_alias():
+    """MOBILE_GPUS is the same dict as MOBILE_GPU_SPECS."""
+    assert MOBILE_GPUS is MOBILE_GPU_SPECS
+
+
+# --- Spec validation ---
+
+def test_all_mobile_gpus_have_vulkan():
+    for name, gpu in MOBILE_GPU_SPECS.items():
+        assert gpu.vulkan_supported, f"{name} must support Vulkan"
+
+
+def test_all_specs_have_positive_bandwidth():
+    for name, gpu in MOBILE_GPU_SPECS.items():
+        assert gpu.memory_bandwidth_gbps > 0, f"{name} bandwidth must be positive"
+        assert gpu.max_vgprs > 0, f"{name} max_vgprs must be positive"
+        assert gpu.shader_cores > 0, f"{name} shader_cores must be positive"
+        assert gpu.fp16_tflops > 0, f"{name} fp16_tflops must be positive"
+
+
+def test_adreno_wavefront_size_64():
+    for name, gpu in MOBILE_GPU_SPECS.items():
+        if gpu.vendor == "qualcomm":
+            assert gpu.wavefront_size == 64, f"{name} should have wavefront_size=64"
+
+
+def test_mali_wavefront_size_16():
+    for name, gpu in MOBILE_GPU_SPECS.items():
+        if gpu.vendor == "arm":
+            assert gpu.wavefront_size == 16, f"{name} should have wavefront_size=16"
+
+
+def test_gpu_spec_frozen():
+    with pytest.raises(AttributeError):
+        ADRENO_750.shader_cores = 8  # type: ignore
+
+
+def test_lds_size_bytes():
+    assert ADRENO_750.lds_size_bytes == 32 * 1024
+    assert MALI_G720.lds_size_bytes == 16 * 1024
+
+
+# --- Occupancy calculations ---
+
+def test_adreno_max_vgpr_waves_zero():
+    """Zero VGPRs means max waves."""
+    assert ADRENO_750.max_vgpr_waves(0) == 16
+
+
+def test_adreno_max_vgpr_waves_moderate():
+    # 128 VGPRs -> 256/128 = 2
+    assert ADRENO_750.max_vgpr_waves(128) == 2
+
+
+def test_adreno_max_vgpr_waves_full():
+    # 256 VGPRs -> 256/256 = 1
+    assert ADRENO_750.max_vgpr_waves(256) == 1
+
+
+def test_mali_max_vgpr_waves_zero():
+    """Zero VGPRs means max waves."""
+    assert MALI_G720.max_vgpr_waves(0) == 8
+
+
+def test_mali_max_vgpr_waves_moderate():
+    # 32 VGPRs -> 64/32 = 2
+    assert MALI_G720.max_vgpr_waves(32) == 2
+
+
+def test_mali_max_vgpr_waves_full():
+    # 64 VGPRs -> 64/64 = 1
+    assert MALI_G720.max_vgpr_waves(64) == 1
+
+
+def test_adreno_max_lds_waves_zero():
+    """Zero LDS means max waves."""
+    assert ADRENO_750.max_lds_waves(0, 256) == 16
+
+
+def test_adreno_max_lds_waves_moderate():
+    # 8192 LDS bytes, 128 threads
+    # wgs_per_core = 32768 / 8192 = 4
+    # waves_per_wg = 128 / 64 = 2
+    # total_waves = 4 * 2 = 8
+    # capped at 8 (< max 16)
+    assert ADRENO_750.max_lds_waves(8192, 128) == 8
+
+
+def test_adreno_max_lds_waves_high():
+    # 32768 LDS bytes = all of it, 64 threads
+    # wgs_per_core = 32768 / 32768 = 1
+    # waves_per_wg = 64 / 64 = 1
+    # total_waves = 1 * 1 = 1
+    assert ADRENO_750.max_lds_waves(32768, 64) == 1
+
+
+def test_mali_max_lds_waves_moderate():
+    # 4096 LDS bytes, 64 threads
+    # wgs_per_core = 16384 / 4096 = 4
+    # waves_per_wg = 64 / 16 = 4
+    # total_waves = 4 * 4 = 16
+    # capped at 8
+    assert MALI_G720.max_lds_waves(4096, 64) == 8
+
+
+def test_occupancy_vgpr_limited():
+    # Adreno 750: 256 VGPRs used -> 1 wave, no LDS -> 16 waves
+    pct, factor = ADRENO_750.occupancy(vgpr_count=256, lds_bytes=0, threads_per_wg=64)
+    assert pct == pytest.approx(6.25)  # 1/16 * 100
+    assert factor == "vgpr"
+
+
+def test_occupancy_lds_limited():
+    # Adreno 750: 0 VGPRs -> 16 waves, 32 KB LDS + 64 threads -> 1 wave
+    pct, factor = ADRENO_750.occupancy(vgpr_count=0, lds_bytes=32768, threads_per_wg=64)
+    assert pct == pytest.approx(6.25)  # 1/16 * 100
+    assert factor == "lds"
+
+
+def test_occupancy_balanced():
+    pct, factor = ADRENO_750.occupancy(vgpr_count=0, lds_bytes=0, threads_per_wg=64)
+    assert pct == 100.0
+    assert factor == "balanced"
+
+
+def test_mali_occupancy_vgpr_limited():
+    # Mali G720: 64 VGPRs -> 1 wave, no LDS -> 8 waves
+    pct, factor = MALI_G720.occupancy(vgpr_count=64, lds_bytes=0, threads_per_wg=16)
+    assert pct == pytest.approx(12.5)  # 1/8 * 100
+    assert factor == "vgpr"
+
+
+# --- Bandwidth ordering ---
+
+def test_adreno_bandwidth_ordering():
+    assert ADRENO_740.memory_bandwidth_gbps < ADRENO_750.memory_bandwidth_gbps < ADRENO_830.memory_bandwidth_gbps
+
+
+def test_mali_bandwidth_ordering():
+    assert MALI_G715.memory_bandwidth_gbps < MALI_G720.memory_bandwidth_gbps < MALI_G820.memory_bandwidth_gbps
+
+
+def test_spec_count():
+    """We should have 6 mobile GPU specs (3 Adreno + 3 Mali)."""
+    assert len(MOBILE_GPU_SPECS) == 6
+    qualcomm = [g for g in MOBILE_GPU_SPECS.values() if g.vendor == "qualcomm"]
+    arm = [g for g in MOBILE_GPU_SPECS.values() if g.vendor == "arm"]
+    assert len(qualcomm) == 3
+    assert len(arm) == 3

--- a/tests/test_rdna3.py
+++ b/tests/test_rdna3.py
@@ -1,5 +1,7 @@
 """Tests for RDNA3 hardware constants and occupancy calculations."""
-from kernel_anvil.rdna3 import GFX1100, GFX1101, GFX1102, GPU_SPECS, GpuSpec
+from unittest.mock import patch
+
+from kernel_anvil.rdna3 import GFX1100, GFX1101, GFX1102, GPU_SPECS, GpuSpec, detect_gpu
 
 
 def test_max_vgpr_waves_128():
@@ -100,3 +102,40 @@ def test_all_specs_wave_size_32():
 
 def test_gfx1102_lower_bandwidth():
     assert GFX1102.peak_bandwidth_gbs < GFX1101.peak_bandwidth_gbs < GFX1100.peak_bandwidth_gbs
+
+
+# detect_gpu name-matching: ROCm reports several iGPUs as 'AMD Radeon Graphics'
+# generically. The substring 'radeon graphics' must NOT classify them as a
+# 7900 XTX (96 CUs, 960 GB/s) -- that produced wildly wrong occupancy and
+# bandwidth heuristics for any iGPU user.
+
+def _detect_with_name(fake_name: str):
+    """Run detect_gpu against a synthesized torch.cuda device name. We also
+    suppress the rocm-smi short-circuit so the torch path actually runs --
+    on the host's real 7900 XTX, rocm-smi would otherwise short-circuit to
+    GFX1100 regardless of the synthesized name."""
+    import subprocess
+    import torch
+    fake_rocm_smi_result = subprocess.CompletedProcess(
+        args=["rocm-smi", "--showproductname"], returncode=0, stdout="", stderr=""
+    )
+    with patch("subprocess.run", return_value=fake_rocm_smi_result), \
+         patch.object(torch.cuda, "is_available", return_value=True), \
+         patch.object(torch.cuda, "get_device_name", return_value=fake_name):
+        return detect_gpu()
+
+
+def test_detect_gpu_does_not_classify_generic_radeon_graphics_as_7900xtx():
+    # An iGPU reported as 'AMD Radeon Graphics' (no specific model string)
+    # must return None -- not GFX1100, not any other GFX spec. Pinning the
+    # exact behavior catches a regression where the substring match falls
+    # back to a different RDNA3 desktop spec by accident.
+    assert _detect_with_name("AMD Radeon Graphics") is None
+
+
+def test_detect_gpu_still_matches_7900_xtx():
+    assert _detect_with_name("AMD Radeon RX 7900 XTX") is GFX1100
+
+
+def test_detect_gpu_still_matches_gfx1100():
+    assert _detect_with_name("gfx1100") is GFX1100

--- a/tests/test_vulkan_mobile_sweep.py
+++ b/tests/test_vulkan_mobile_sweep.py
@@ -1,0 +1,149 @@
+"""Tests for Vulkan mobile sweep configuration generation."""
+import pytest
+
+from kernel_anvil.mobile import ADRENO_750, ADRENO_830, MALI_G720, MALI_G715
+from kernel_anvil.vulkan_mobile_sweep import (
+    MobileSweepConfig,
+    MobileSweepResult,
+    generate_mobile_configs,
+    sweep_mobile,
+    sweep_all_mobile,
+)
+
+
+# --- Config generation ---
+
+def test_generate_adreno_configs():
+    configs = generate_mobile_configs(ADRENO_750)
+    assert len(configs) > 0
+    assert all(isinstance(c, MobileSweepConfig) for c in configs)
+
+
+def test_generate_mali_configs():
+    configs = generate_mobile_configs(MALI_G720)
+    assert len(configs) > 0
+    assert all(isinstance(c, MobileSweepConfig) for c in configs)
+
+
+def test_configs_sorted_by_score():
+    configs = generate_mobile_configs(ADRENO_750)
+    scores = [c.score for c in configs]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_max_configs_respected():
+    configs = generate_mobile_configs(ADRENO_750, max_configs=3)
+    assert len(configs) <= 3
+
+
+def test_adreno_workgroup_sizes_aligned():
+    """All Adreno configs should have workgroup sizes that are multiples of 64."""
+    configs = generate_mobile_configs(ADRENO_750)
+    for c in configs:
+        assert c.workgroup_size % 64 == 0, (
+            f"Adreno workgroup size {c.workgroup_size} not aligned to wavefront"
+        )
+
+
+def test_mali_workgroup_sizes_aligned():
+    """All Mali configs should have workgroup sizes that are multiples of 16."""
+    configs = generate_mobile_configs(MALI_G720)
+    for c in configs:
+        assert c.workgroup_size % 16 == 0, (
+            f"Mali workgroup size {c.workgroup_size} not aligned to warp"
+        )
+
+
+def test_configs_have_valid_occupancy():
+    configs = generate_mobile_configs(ADRENO_750)
+    for c in configs:
+        assert 0 < c.estimated_occupancy_pct <= 100.0
+        assert c.limiting_factor in ("vgpr", "lds", "balanced")
+
+
+def test_configs_have_valid_bandwidth_utilization():
+    configs = generate_mobile_configs(MALI_G720)
+    for c in configs:
+        assert 0 < c.bandwidth_utilization <= 1.0
+
+
+def test_configs_have_valid_score():
+    configs = generate_mobile_configs(ADRENO_830)
+    for c in configs:
+        assert 0 < c.score <= 1.0
+
+
+def test_config_label_format():
+    configs = generate_mobile_configs(ADRENO_750, max_configs=1)
+    label = configs[0].label
+    assert label.startswith("wg=")
+    assert "_rows=" in label
+
+
+# --- Sweep function ---
+
+def test_sweep_mobile_adreno():
+    result = sweep_mobile("adreno-750")
+    assert result is not None
+    assert isinstance(result, MobileSweepResult)
+    assert result.gpu is ADRENO_750
+    assert result.quant_type == "turbo3_0"
+    assert result.best is result.configs[0]
+    assert len(result.configs) > 0
+
+
+def test_sweep_mobile_mali():
+    result = sweep_mobile("mali-g720")
+    assert result is not None
+    assert result.gpu is MALI_G720
+
+
+def test_sweep_mobile_unknown():
+    result = sweep_mobile("nonexistent-gpu")
+    assert result is None
+
+
+def test_sweep_mobile_custom_quant():
+    result = sweep_mobile("adreno-830", quant_type="q4_k")
+    assert result is not None
+    assert result.quant_type == "q4_k"
+
+
+# --- Sweep all ---
+
+def test_sweep_all_mobile():
+    results = sweep_all_mobile(max_configs=3)
+    assert len(results) == 6  # 3 Adreno + 3 Mali
+    for name, result in results.items():
+        assert result.gpu.name  # not empty
+        assert len(result.configs) <= 3
+        assert result.best is result.configs[0]
+
+
+def test_sweep_all_has_both_vendors():
+    results = sweep_all_mobile(max_configs=1)
+    vendors = {r.gpu.vendor for r in results.values()}
+    assert "qualcomm" in vendors
+    assert "arm" in vendors
+
+
+# --- Cross-GPU consistency ---
+
+def test_adreno_830_higher_score_than_740():
+    """Adreno 830 should generally achieve equal or better scores than 740
+    (more shader cores, higher bandwidth, same arch constraints)."""
+    r830 = sweep_mobile("adreno-830", max_configs=1)
+    r740 = sweep_mobile("adreno-740", max_configs=1)
+    assert r830 is not None and r740 is not None
+    # Best config scores should be comparable (same workgroup logic)
+    # Just verify both produce valid results
+    assert r830.best.score > 0
+    assert r740.best.score > 0
+
+
+def test_mali_g820_higher_bandwidth():
+    """Mali G820 should have higher bandwidth than G715."""
+    r820 = sweep_mobile("mali-g820", max_configs=1)
+    r715 = sweep_mobile("mali-g715", max_configs=1)
+    assert r820 is not None and r715 is not None
+    assert r820.gpu.memory_bandwidth_gbps > r715.gpu.memory_bandwidth_gbps


### PR DESCRIPTION
## Summary

Closes #9. Adds first-class support for llama.cpp's speculative decoding via two new commands — no llama.cpp patch changes needed (the runtime loader is already model-agnostic).

- `kernel-anvil gguf-optimize <target> --draft <draft>` (repeatable) profiles target + draft GGUFs together and writes a single merged JSON config keyed under the target stem. Bucket-cell collisions resolve to the higher profiled speedup so the better-performing config survives.
- `kernel-anvil merge-configs <a.json> <b.json> -o <merged.json>` combines pre-existing per-model JSONs (first-listed wins on bucket-cell conflicts).

## Bug fixes from a multi-pass audit

While verifying the new feature I ran a thorough audit and fixed a stack of pre-existing issues with regression tests for each:

**C parser hardening (`patches/smithy-config.h`)**

- CRITICAL: `strchr(NULL, ...)` on malformed JSON could crash llama.cpp.
- Cross-cell strstr leak (one cell could absorb another's `nwarps` / `rows_per_block`).
- Type-level value mis-attribution (no-brace value mis-loaded sibling type's body).
- Configs object boundary not enforced (sibling top-level keys silently became kernel configs).
- Depth scanners were string-unaware, so `}` inside a string literal truncated bodies and dropped or re-attributed cells.
- Data races on `smithy_configs[][][]` (`smithy_lookup` was lock-free); now uses `std::shared_mutex` with reader-side `shared_lock`, writers exclusive.

**Python / CLI fixes**

- `gguf-optimize --draft` Run hint omitted `-md`, silently disabling speculative decoding for users who copy-pasted the suggested command.
- Failed target-profiling poisoned the shape slot, blocking draft recovery.
- `merge_runtime_configs` raw-traceback'd on malformed payloads.
- Test fixtures wrote to the user's real `~/.cache/smithy/`.
- `model.py` partial-cache + no-GPU saved defaults over a partial cache, poisoning future GPU-equipped runs.
- NaN priority could overwrite a real-priority cell.
- `rdna3.py` matched generic `AMD Radeon Graphics` iGPUs as a 7900 XTX.
- `llama_sweep.py` SQL `LIKE` wildcard accepted non-underscore matches and let an `OperationalError` escape on missing symbol tables; now warns on unknown quant types.
- Atomic-write tempfile cleanup leaked on non-`OSError` exceptions.

**Packaging**

- `setuptools` floor lifted to `>=77.0` (PEP 639 SPDX `license = "Apache-2.0"` needs it; older setuptools rejected the SPDX form at install).
- `MANIFEST.in` added so `patches/` + `examples/` ship in the sdist.

## Verification

- 262 tests pass / 13 skipped, deterministic across repeated runs (24 new defensive tests).
- C parser verified against 7,636 random property-fuzz inputs (0 crashes, 0 property violations) under ASan + UBSan.
- TSan stress: 5.3M concurrent reads + many concurrent writes against the new `shared_mutex` lookup — zero races.
- End-to-end speculative-decoding round-trip: Python emit → C parser load → identical cells.

## Test plan
- [x] `python -m pytest -q` (262 passed / 13 skipped, repeated runs clean)
- [x] `g++ -std=c++17 -Wall -Wextra` clean compile of `patches/smithy-config.h`
- [x] TSan stress run with concurrent readers + writer (0 races)
- [x] `kernel-anvil gguf-optimize --draft` end-to-end with mocked GGUFs
- [x] `kernel-anvil merge-configs` first-wins semantics + malformed-JSON error paths
- [ ] Manual integration with a real llama.cpp speculative-decoding run (requires the patch to be applied to a fresh llama.cpp tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)