### PR TITLE
feat: train-optimize subcommand for mud-puppy training-kernel autotune

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,22 @@ kernel-anvil sweep examples/simple_gemv.py
 kernel-anvil profile examples/simple_gemv.py
 ```
 
+### Tune training-time kernels (mud-puppy)
+
+`train-optimize` is the training-side counterpart of `gguf-optimize`. Given a Hugging Face model id and a `(batch, seq)` pair, it walks the HF config, enumerates the unique `(op, M, N, K)` GEMM shapes the forward and grad-input kernels will see during fine-tuning, sweeps Triton configs against [mud-puppy](https://github.com/apollosenvy/mud-puppy)'s training kernels, and writes an `anvil-train/v1` JSON to `~/.cache/anvil-train/<gpu>/<model>-<quant>-b<B>s<S>.json`. mud-puppy's `anvil_loader` reads the cache at startup to pick per-shape configs.
+
+```bash
+kernel-anvil train-optimize Qwen/Qwen3-8B \
+    --quant mxfp4 --batch 1 --seq 4096 \
+    --mud-puppy-path /path/to/mud-puppy
+
+# Dry-run (no GPU): emit a JSON skeleton with placeholder configs.
+kernel-anvil train-optimize Qwen/Qwen3-8B \
+    --quant int4 --batch 1 --seq 4096 --dry-run
+```
+
+Supported architectures: `LlamaConfig`, `Qwen3Config`, `GptOssConfig` (MoE -- per-expert irregular-M shapes are bucketed). Default ops: `mxfp4_fwd`, `mxfp4_grad_input`, `int4_fwd`, `int4_grad_input`.
+
 ### Other commands
 
 | Command | Purpose |

--- a/kernel_anvil/cli.py
+++ b/kernel_anvil/cli.py
@@ -1,8 +1,10 @@
 """CLI for kernel-anvil -- profile-guided Triton kernel optimizer."""
 import argparse
 import importlib.util
+import json
 import os
 import sys
+import tempfile
 import time
 from pathlib import Path
 
@@ -716,6 +718,398 @@ def cmd_llama_sweep(args):
     console.print(f"\n[dim]Run llama.cpp with: SMITHY_CONFIG={path} llama-server -m {args.gguf} -ngl 999[/dim]")
 
 
+def _atomic_write_text(path: Path, text: str) -> None:
+    """Atomically write text to ``path`` via a tempfile + os.rename.
+
+    Mirrors the cmd_gguf_optimize pattern so train-optimize gets the same
+    crash-safety guarantees (no truncated JSON on Ctrl-C, no leftover
+    `.json.tmp` files in the cache dir).
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".json.tmp")
+    try:
+        with os.fdopen(tmp_fd, "w") as f:
+            f.write(text)
+        os.rename(tmp_path, str(path))
+    finally:
+        if Path(tmp_path).exists():
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def _resolve_train_runner(op: str, mud_puppy_path: str | None):
+    """Look up a mud-puppy training runner module for the given op.
+
+    The runner contract lives in `mud_puppy.anvil_runner.<op>_runner` (e.g.
+    `mxfp4_fwd_runner`). When ``mud_puppy_path`` is provided we prepend it
+    to sys.path so the import resolves against a checkout that isn't
+    pip-installed.
+
+    Returns the module object on success, None when the runner is not
+    importable. Caller decides whether to skip (dry-run) or hard-fail.
+    """
+    if mud_puppy_path:
+        mp_path = str(Path(mud_puppy_path).resolve())
+        if mp_path not in sys.path:
+            sys.path.insert(0, mp_path)
+    try:
+        import importlib
+
+        module_name = f"mud_puppy.anvil_runner.{op}_runner"
+        return importlib.import_module(module_name)
+    except Exception:
+        return None
+
+
+def _train_dry_run_config(M: int, N: int, K: int) -> dict:
+    """Synthetic 'best config' used when no GPU/runner is available.
+
+    The default mirrors the empirical winner from the headroom benchmark
+    (BLOCK_M=128, BLOCK_N=64, BLOCK_K=32, GROUP_M=8, num_warps=8,
+    num_stages=4) so dry-run JSON skeletons are immediately useful as a
+    starting point if a real sweep can't be done."""
+    return {
+        "BLOCK_M": 128,
+        "BLOCK_N": 64,
+        "BLOCK_K": 32,
+        "GROUP_M": 8,
+        "num_warps": 8,
+        "num_stages": 4,
+        "speedup_vs_baseline": 1.0,
+        "profiled_us": 0.0,
+    }
+
+
+def _tune_train_shape(
+    *,
+    runner_module,
+    op: str,
+    M: int,
+    N: int,
+    K: int,
+    gpu_spec,
+    max_configs: int,
+    warmup: int,
+    runs: int,
+) -> tuple[dict, float, float | None]:
+    """Sweep a single (op, M, N, K) shape via a mud-puppy runner module.
+
+    The runner is expected to expose:
+        - `make_inputs(M, N, K) -> inputs` (preferred) OR `setup() -> inputs`
+        - `reference(inputs) -> tensor or tuple`
+        - `run(inputs, **config) -> tensor or tuple`
+        - optional `BASELINE_CONFIG` and `DATA_BYTES`
+        - optional `OUTPUT_INDEX` for which slot to allclose-check (default 0)
+
+    Returns ``(best_payload, baseline_us, speedup_or_None)`` where
+    `best_payload` is a dict suitable for `train_codegen.generate_train_runtime_config`.
+    """
+    from kernel_anvil.train_param_space import generate_train_configs
+
+    # Build inputs. Prefer make_inputs(M, N, K) if exposed; fall back to
+    # setup() with no args (legacy contract).
+    if hasattr(runner_module, "make_inputs"):
+        inputs = runner_module.make_inputs(M, N, K)
+    else:
+        inputs = runner_module.setup()
+
+    ref = runner_module.reference(inputs)
+    output_index = int(getattr(runner_module, "OUTPUT_INDEX", 0))
+    baseline_config = dict(getattr(runner_module, "BASELINE_CONFIG", {}) or {})
+    data_bytes = getattr(runner_module, "DATA_BYTES", None)
+
+    def kernel_fn(cfg):
+        return runner_module.run(inputs, **cfg)
+
+    # Baseline benchmark (if BASELINE_CONFIG present, otherwise skip).
+    baseline_latency = None
+    if baseline_config:
+        try:
+            baseline_result = verify_and_bench(
+                kernel_fn=kernel_fn,
+                reference_output=ref,
+                config=baseline_config,
+                warmup=warmup,
+                runs=runs,
+                data_bytes=data_bytes,
+                output_index=output_index,
+            )
+            baseline_latency = baseline_result.latency_us
+        except Exception:
+            baseline_latency = None
+
+    # Generate candidate configs and benchmark each.
+    candidates = generate_train_configs(gpu=gpu_spec, max_configs=max_configs)
+    best_cfg = baseline_config or candidates[0] if candidates else baseline_config
+    best_latency = baseline_latency if baseline_latency is not None else float("inf")
+
+    for cfg in candidates:
+        try:
+            result = verify_and_bench(
+                kernel_fn=kernel_fn,
+                reference_output=ref,
+                config=cfg,
+                warmup=warmup,
+                runs=runs,
+                data_bytes=data_bytes,
+                baseline_latency_us=baseline_latency,
+                atol=1e-2,
+                rtol=1e-2,
+                output_index=output_index,
+            )
+            if result.correct and result.latency_us < best_latency:
+                best_latency = result.latency_us
+                best_cfg = cfg
+        except Exception:
+            continue
+
+    if best_cfg is None:
+        # Everything failed -- emit a dry-run payload so the JSON layer
+        # still has a sensible default for this cell.
+        return _train_dry_run_config(M, N, K), baseline_latency or 0.0, None
+
+    speedup = None
+    if baseline_latency is not None and best_latency > 0:
+        speedup = baseline_latency / best_latency
+
+    payload = {
+        "BLOCK_M": int(best_cfg.get("BLOCK_M", 128)),
+        "BLOCK_N": int(best_cfg.get("BLOCK_N", 64)),
+        "BLOCK_K": int(best_cfg.get("BLOCK_K", 32)),
+        "GROUP_M": int(best_cfg.get("GROUP_M", 8)),
+        "num_warps": int(best_cfg.get("num_warps", 8)),
+        "num_stages": int(best_cfg.get("num_stages", 4)),
+    }
+    if speedup is not None:
+        payload["speedup_vs_baseline"] = float(speedup)
+    if best_latency != float("inf"):
+        payload["profiled_us"] = float(best_latency)
+    return payload, float(baseline_latency or 0.0), speedup
+
+
+def cmd_train_optimize(args):
+    """Profile training-time GEMM shapes for a model and emit anvil-train JSON.
+
+    The training-side counterpart of `cmd_gguf_optimize`. Walks the HF
+    model config, enumerates the unique (op, M, N, K) shapes for the given
+    (batch, seq), runs a sweep against the mud-puppy runner for each, and
+    writes a v1 JSON to `~/.cache/anvil-train/<gpu>/<model>-<quant>-bN-sM.json`.
+
+    When mud-puppy isn't importable (no ``--mud-puppy-path`` and no
+    installed package), falls back to a dry-run mode that emits a JSON
+    skeleton with placeholder configs -- useful for testing the JSON layer
+    on a CPU-only box.
+    """
+    from kernel_anvil.train_codegen import generate_train_runtime_config
+    from kernel_anvil.train_shapes import extract_shapes, model_basename
+
+    # Resolve quant -> ops mapping
+    quant = args.quant
+    if quant not in ("mxfp4", "int4"):
+        console.print(f"[red]Unknown quant: {quant} (expected mxfp4 or int4)[/red]")
+        sys.exit(1)
+
+    if args.ops:
+        ops = [s.strip() for s in args.ops.split(",") if s.strip()]
+    else:
+        ops = [f"{quant}_fwd", f"{quant}_grad_input"]
+
+    dry_run = bool(getattr(args, "dry_run", False))
+
+    # Detect GPU for cache-path stamping (always succeeds; falls back to GFX1100).
+    if dry_run:
+        gpu_spec = GFX1100
+        device = None
+        console.print("[yellow]--dry-run: emitting JSON skeleton, no GPU benchmarking[/yellow]")
+    else:
+        if not torch.cuda.is_available():
+            console.print(
+                "[yellow]GPU not detected -- falling back to --dry-run mode."
+                " Install a ROCm PyTorch build to benchmark training kernels.[/yellow]"
+            )
+            dry_run = True
+            gpu_spec = GFX1100
+            device = None
+        else:
+            gpu_spec = _get_gpu_spec()
+            device = torch.device("cuda")
+
+    # Pull shapes
+    console.print(f"\n[bold]Extracting training shapes for {args.model}...[/bold]")
+    try:
+        shapes = extract_shapes(args.model, batch=args.batch, seq=args.seq, ops=ops)
+    except Exception as exc:
+        console.print(f"[red]Failed to extract shapes: {exc}[/red]")
+        sys.exit(1)
+
+    if not shapes:
+        console.print("[yellow]No shapes extracted -- nothing to do.[/yellow]")
+        sys.exit(0)
+
+    console.print(f"[dim]{len(shapes)} unique (op, M, N, K) tuples[/dim]")
+
+    # Resolve runners (one per op family)
+    runners: dict[str, object] = {}
+    if not dry_run:
+        for op in ops:
+            mod = _resolve_train_runner(op, args.mud_puppy_path)
+            if mod is None:
+                console.print(
+                    f"[yellow]Runner for {op!r} not available (no mud-puppy on path);"
+                    f" falling back to dry-run for this op.[/yellow]"
+                )
+            runners[op] = mod
+        if all(r is None for r in runners.values()):
+            console.print(
+                "[yellow]No runners resolved -- switching entire run to --dry-run mode.[/yellow]"
+            )
+            dry_run = True
+
+    # Sweep loop
+    configs: dict[tuple[str, int, int, int], dict] = {}
+    speedups: dict[tuple[str, int, int, int], float] = {}
+    results_table_rows: list = []
+    total_t0 = time.monotonic()
+
+    for i, (op, M, N, K) in enumerate(shapes, 1):
+        runner = runners.get(op) if not dry_run else None
+        t0 = time.monotonic()
+        if runner is None or dry_run:
+            payload = _train_dry_run_config(M, N, K)
+            speedup = None
+            baseline_us = 0.0
+        else:
+            try:
+                payload, baseline_us, speedup = _tune_train_shape(
+                    runner_module=runner,
+                    op=op,
+                    M=M,
+                    N=N,
+                    K=K,
+                    gpu_spec=gpu_spec,
+                    max_configs=args.max_configs,
+                    warmup=args.warmup,
+                    runs=args.runs,
+                )
+            except Exception as exc:
+                console.print(f"  [{i}/{len(shapes)}] {op} ({M},{N},{K}): [red]FAILED[/red] {exc}")
+                payload = _train_dry_run_config(M, N, K)
+                speedup = None
+                baseline_us = 0.0
+        configs[(op, M, N, K)] = payload
+        if speedup is not None:
+            speedups[(op, M, N, K)] = float(speedup)
+        dt = time.monotonic() - t0
+        results_table_rows.append((op, M, N, K, payload, baseline_us, speedup, dt))
+        if speedup is not None:
+            console.print(
+                f"  [{i}/{len(shapes)}] {op} ({M},{N},{K}): "
+                f"BLOCK_M={payload['BLOCK_M']} BLOCK_N={payload['BLOCK_N']} "
+                f"BLOCK_K={payload['BLOCK_K']} ({speedup:.2f}x, {dt:.1f}s)"
+            )
+        else:
+            tag = "dry-run" if dry_run or runner is None else "no-baseline"
+            console.print(
+                f"  [{i}/{len(shapes)}] {op} ({M},{N},{K}): "
+                f"BLOCK_M={payload['BLOCK_M']} BLOCK_N={payload['BLOCK_N']} "
+                f"BLOCK_K={payload['BLOCK_K']} ({tag})"
+            )
+
+    total_dt = time.monotonic() - total_t0
+
+    # Print summary table
+    table = Table(title="Train-Optimize Results")
+    table.add_column("Op", style="cyan")
+    table.add_column("M", justify="right")
+    table.add_column("N", justify="right")
+    table.add_column("K", justify="right")
+    table.add_column("BLOCK_M/N/K", justify="right")
+    table.add_column("warps", justify="right")
+    table.add_column("stages", justify="right")
+    table.add_column("Baseline (us)", justify="right")
+    table.add_column("Speedup", justify="right")
+    table.add_column("Time", justify="right", style="dim")
+
+    for op, M, N, K, payload, baseline_us, speedup, dt in results_table_rows:
+        speedup_str = (
+            f"[green]{speedup:.2f}x[/green]" if speedup is not None and speedup > 1.0
+            else (f"{speedup:.2f}x" if speedup is not None else "-")
+        )
+        tile_str = f"{payload['BLOCK_M']}/{payload['BLOCK_N']}/{payload['BLOCK_K']}"
+        table.add_row(
+            op, str(M), str(N), str(K),
+            tile_str,
+            str(payload["num_warps"]),
+            str(payload["num_stages"]),
+            f"{baseline_us:.1f}" if baseline_us else "-",
+            speedup_str,
+            f"{dt:.1f}s",
+        )
+
+    console.print()
+    console.print(table)
+    console.print(f"\nTotal tuning time: {total_dt:.1f}s")
+
+    # Build the JSON payload
+    model_id = args.model
+    basename = model_basename(model_id)
+    rocm_version = _detect_rocm_version()
+    torch_version = getattr(torch, "__version__", "")
+    triton_version = _detect_triton_version()
+
+    json_text = generate_train_runtime_config(
+        configs,
+        gpu=gpu_spec.gfx,
+        model=basename,
+        batch=args.batch,
+        seq=args.seq,
+        rocm_version=rocm_version,
+        torch_version=torch_version,
+        triton_version=triton_version,
+        kernel_hash="",  # populated by mud-puppy on the loader side
+        priorities={k: int(v * 1000) for k, v in speedups.items()} or None,
+    )
+
+    # Resolve output path
+    if args.output:
+        out_path = Path(args.output).expanduser().resolve()
+    else:
+        out_path = (
+            Path.home() / ".cache" / "anvil-train" / gpu_spec.gfx
+            / f"{basename}-{quant}-b{args.batch}s{args.seq}.json"
+        )
+    _atomic_write_text(out_path, json_text)
+
+    console.print(f"\n[bold green]anvil-train config written to {out_path}[/bold green]")
+    if dry_run:
+        console.print(
+            "[dim]Dry-run JSON. Re-run with mud-puppy on the path and a GPU"
+            " to populate real configs.[/dim]"
+        )
+
+
+def _detect_rocm_version() -> str:
+    """Best-effort ROCm version string. Empty when unavailable."""
+    try:
+        info_file = Path("/opt/rocm/.info/version")
+        if info_file.exists():
+            return info_file.read_text().strip()
+    except OSError:
+        pass
+    return ""
+
+
+def _detect_triton_version() -> str:
+    try:
+        import triton  # type: ignore
+
+        return getattr(triton, "__version__", "")
+    except Exception:
+        return ""
+
+
 def cmd_compare(args):
     """Compare ROCm vs Vulkan backend performance."""
     from kernel_anvil.vulkan_sweep import compare_backends
@@ -800,6 +1194,55 @@ def main():
     p_llama.add_argument("--llama-bench", help="Path to llama-bench binary")
     p_llama.add_argument("--nwarps", default="1,2,4,8", help="Comma-separated nwarps to try (default: 1,2,4,8)")
 
+    # train-optimize: profile training-side GEMM shapes for mud-puppy
+    p_train = sub.add_parser(
+        "train-optimize",
+        help="Tune training-time GEMM kernels (mxfp4/int4 fwd + grad-input)"
+             " against an HF model + (batch, seq) shape -- emits anvil-train v1 JSON.",
+    )
+    p_train.add_argument("model", help="HF model id (e.g. Qwen/Qwen3-8B) or local path")
+    p_train.add_argument(
+        "--quant",
+        choices=("mxfp4", "int4"),
+        required=True,
+        help="Quantization scheme to tune (selects op set unless --ops is given)",
+    )
+    p_train.add_argument("--batch", type=int, required=True, help="Per-device batch size")
+    p_train.add_argument("--seq", type=int, required=True, help="Training sequence length")
+    p_train.add_argument(
+        "--ops",
+        default="",
+        help="Comma-separated op list. Default: <quant>_fwd,<quant>_grad_input",
+    )
+    p_train.add_argument(
+        "--mud-puppy-path",
+        default=None,
+        help="Path to a mud-puppy checkout (prepended to sys.path so"
+             " mud_puppy.anvil_runner.<op>_runner imports resolve).",
+    )
+    p_train.add_argument(
+        "--output",
+        default=None,
+        help="Output JSON path. Default: ~/.cache/anvil-train/<gpu>/<model>-<quant>-b<B>s<S>.json",
+    )
+    p_train.add_argument(
+        "--max-configs", type=int, default=30,
+        help="Cap on Triton configs per shape (default: 30).",
+    )
+    p_train.add_argument(
+        "--warmup", type=int, default=3,
+        help="Warmup iterations per benchmark (default: 3).",
+    )
+    p_train.add_argument(
+        "--runs", type=int, default=5,
+        help="Timed iterations per benchmark (default: 5).",
+    )
+    p_train.add_argument(
+        "--dry-run", action="store_true",
+        help="Skip GPU benchmarking; emit a JSON skeleton with placeholder"
+             " configs. Useful for testing the JSON layer without a GPU.",
+    )
+
     # compare: head-to-head ROCm vs Vulkan
     p_compare = sub.add_parser("compare-backends", help="Compare ROCm vs Vulkan decode performance")
     p_compare.add_argument("gguf", help="Path to GGUF model file")
@@ -825,6 +1268,8 @@ def main():
         cmd_compare(args)
     elif args.command == "merge-configs":
         cmd_merge_configs(args)
+    elif args.command == "train-optimize":
+        cmd_train_optimize(args)
 
 
 if __name__ == "__main__":

--- a/kernel_anvil/train_codegen.py
+++ b/kernel_anvil/train_codegen.py
@@ -1,0 +1,356 @@
+"""Code generation for the anvil-train JSON v1 schema.
+
+The training-side counterpart of `codegen.py`. Where the inference codegen
+emits llama.cpp `smithy_configs` C-style tables keyed on (ggml_type, N, K),
+this module emits a JSON contract consumed by mud-puppy's anvil_loader and
+keyed on (op_name, M, N, K) -- a 3D bucket scheme.
+
+Schema (anvil-train/v1):
+
+```json
+{
+  "schema": "anvil-train/v1",
+  "gpu": "gfx1100",
+  "rocm_version": "7.1",
+  "torch_version": "2.10.0+rocm7.1",
+  "triton_version": "3.6.0",
+  "kernel_hash": "sha256:<hex>",
+  "model": "Qwen3-8B",
+  "batch": 1,
+  "seq": 4096,
+  "ops": {
+    "<op_name>": {
+      "<m_bucket>,<n_bucket>,<k_bucket>": {
+        "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+        "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+        "speedup_vs_baseline": 1.33,
+        "profiled_us": 18.4
+      }
+    }
+  }
+}
+```
+
+All bucket boundaries are (1024, 4096, 8192, 16384) -- five buckets per axis.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+# Schema identifier embedded in every emitted payload. Bump when the on-disk
+# layout changes incompatibly.
+SCHEMA_VERSION = "anvil-train/v1"
+
+# Bucket boundaries shared across the M, N, and K axes. A value falls into the
+# first bucket whose boundary it does not exceed; everything larger lands in
+# the final >max bucket.
+BUCKET_BOUNDARIES = (1024, 4096, 8192, 16384)
+NUM_BUCKETS = len(BUCKET_BOUNDARIES) + 1  # +1 for the >max bucket
+
+# Required keys for every per-cell payload. speedup_vs_baseline / profiled_us
+# are optional metadata.
+REQUIRED_PAYLOAD_KEYS = (
+    "BLOCK_M",
+    "BLOCK_N",
+    "BLOCK_K",
+    "GROUP_M",
+    "num_warps",
+    "num_stages",
+)
+
+OPTIONAL_PAYLOAD_KEYS = (
+    "speedup_vs_baseline",
+    "profiled_us",
+)
+
+# Well-known op names. The schema does not enforce membership but consumers
+# should use these to avoid drift.
+KNOWN_OPS = (
+    "mxfp4_fwd",
+    "mxfp4_grad_input",
+    "int4_fwd",
+    "int4_grad_input",
+)
+
+
+@dataclass(frozen=True)
+class TrainShapeConfig:
+    """Per-cell payload for the training JSON.
+
+    Mirrors `ShapeConfig` in `codegen.py` but for training kernels. The
+    optional fields capture sweep telemetry; consumers may safely ignore them.
+    """
+
+    BLOCK_M: int
+    BLOCK_N: int
+    BLOCK_K: int
+    GROUP_M: int
+    num_warps: int
+    num_stages: int
+    speedup_vs_baseline: float | None = None
+    profiled_us: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "BLOCK_M": int(self.BLOCK_M),
+            "BLOCK_N": int(self.BLOCK_N),
+            "BLOCK_K": int(self.BLOCK_K),
+            "GROUP_M": int(self.GROUP_M),
+            "num_warps": int(self.num_warps),
+            "num_stages": int(self.num_stages),
+        }
+        if self.speedup_vs_baseline is not None:
+            out["speedup_vs_baseline"] = float(self.speedup_vs_baseline)
+        if self.profiled_us is not None:
+            out["profiled_us"] = float(self.profiled_us)
+        return out
+
+
+def bucket_index_3d(m: int, n: int, k: int) -> tuple[int, int, int]:
+    """Map an (M, N, K) shape to a (mb, nb, kb) bucket triple.
+
+    Each axis uses the same bucket boundaries, so the function is just three
+    independent 1D bucket lookups. Bucket 0 covers values <= 1024, bucket 4
+    catches anything > 16384.
+    """
+    return (_bucket_index_1d(m), _bucket_index_1d(n), _bucket_index_1d(k))
+
+
+def _bucket_index_1d(value: int) -> int:
+    for i, boundary in enumerate(BUCKET_BOUNDARIES):
+        if value <= boundary:
+            return i
+    return len(BUCKET_BOUNDARIES)
+
+
+def _bucket_label(idx: int) -> str:
+    """Human-readable label for a bucket index."""
+    if idx == 0:
+        return f"<={BUCKET_BOUNDARIES[0]}"
+    if idx < len(BUCKET_BOUNDARIES):
+        return f"<={BUCKET_BOUNDARIES[idx]}"
+    return f">{BUCKET_BOUNDARIES[-1]}"
+
+
+def _coerce_payload(raw: dict[str, Any]) -> TrainShapeConfig | None:
+    """Validate a per-cell config dict and lift it to TrainShapeConfig.
+
+    Returns None for malformed entries (missing required keys, wrong types).
+    First-seen-wins is enforced by the caller; this function only validates.
+    """
+    if not isinstance(raw, dict):
+        return None
+    try:
+        for key in REQUIRED_PAYLOAD_KEYS:
+            if key not in raw:
+                return None
+            # All required fields must be ints (or int-coercible)
+            int(raw[key])
+        speedup = raw.get("speedup_vs_baseline")
+        profiled = raw.get("profiled_us")
+        return TrainShapeConfig(
+            BLOCK_M=int(raw["BLOCK_M"]),
+            BLOCK_N=int(raw["BLOCK_N"]),
+            BLOCK_K=int(raw["BLOCK_K"]),
+            GROUP_M=int(raw["GROUP_M"]),
+            num_warps=int(raw["num_warps"]),
+            num_stages=int(raw["num_stages"]),
+            speedup_vs_baseline=float(speedup) if speedup is not None else None,
+            profiled_us=float(profiled) if profiled is not None else None,
+        )
+    except (TypeError, ValueError):
+        return None
+
+
+def build_op_table(
+    configs: dict[tuple[str, int, int, int], dict[str, Any]],
+    priorities: dict[tuple[str, int, int, int], int] | None = None,
+) -> dict[str, dict[str, dict[str, Any]]]:
+    """Bucket sweep results into the on-disk op table layout.
+
+    Args:
+        configs: Mapping of (op_name, M, N, K) -> per-cell payload dict.
+            Required keys: BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, num_warps,
+            num_stages. Optional: speedup_vs_baseline, profiled_us.
+        priorities: Optional mapping of the same key -> integer priority.
+            When two shapes collide on the same (op, mb, nb, kb) cell, the
+            higher-priority entry wins. With no priorities given, the
+            first-seen entry wins (insertion order).
+
+    Returns:
+        Nested dict shape:
+            { op_name -> { "mb,nb,kb" -> payload_dict } }
+
+        Cells with no sweep data are simply absent (consumer falls back).
+    """
+    priorities = priorities or {}
+    op_table: dict[str, dict[str, dict[str, Any]]] = {}
+    cell_priority: dict[tuple[str, str], int] = {}
+
+    for key, raw in configs.items():
+        if not (isinstance(key, tuple) and len(key) == 4):
+            continue
+        op_name, m, n, k = key
+        if not isinstance(op_name, str) or not op_name:
+            continue
+        try:
+            m_i = int(m)
+            n_i = int(n)
+            k_i = int(k)
+        except (TypeError, ValueError):
+            continue
+        if m_i <= 0 or n_i <= 0 or k_i <= 0:
+            continue
+
+        cfg = _coerce_payload(raw)
+        if cfg is None:
+            continue
+
+        mb, nb, kb = bucket_index_3d(m_i, n_i, k_i)
+        cell_key = f"{mb},{nb},{kb}"
+
+        prio = int(priorities.get(key, 0))
+        existing_prio = cell_priority.get((op_name, cell_key))
+
+        # First-seen-wins when no priority differentiates the two entries.
+        if existing_prio is None or prio > existing_prio:
+            op_table.setdefault(op_name, {})[cell_key] = cfg.to_dict()
+            cell_priority[(op_name, cell_key)] = prio
+
+    return op_table
+
+
+def generate_train_runtime_config(
+    configs: dict[tuple[str, int, int, int], dict[str, Any]],
+    *,
+    gpu: str,
+    model: str,
+    batch: int,
+    seq: int,
+    rocm_version: str = "",
+    torch_version: str = "",
+    triton_version: str = "",
+    kernel_hash: str = "",
+    priorities: dict[tuple[str, int, int, int], int] | None = None,
+) -> str:
+    """Render the full anvil-train JSON v1 payload.
+
+    Args:
+        configs: Same shape as `build_op_table`.
+        gpu: Architecture string (e.g. "gfx1100").
+        model: HF model id or basename (e.g. "Qwen3-8B").
+        batch: Effective M batch dimension used during the sweep.
+        seq: Sequence length used during the sweep.
+        rocm_version / torch_version / triton_version / kernel_hash:
+            Cache-invalidation keys. Mismatch on load means re-tune.
+        priorities: Optional priority map (see `build_op_table`).
+
+    Returns:
+        Pretty-printed JSON string ready to write to disk.
+    """
+    op_table = build_op_table(configs, priorities=priorities)
+
+    payload: dict[str, Any] = {
+        "schema": SCHEMA_VERSION,
+        "gpu": gpu,
+        "rocm_version": rocm_version,
+        "torch_version": torch_version,
+        "triton_version": triton_version,
+        "kernel_hash": kernel_hash,
+        "model": model,
+        "batch": int(batch),
+        "seq": int(seq),
+        "ops": op_table,
+    }
+    return json.dumps(payload, indent=2)
+
+
+def merge_train_runtime_configs(
+    payloads: Iterable[dict[str, Any]],
+    *,
+    gpu: str,
+    model: str,
+) -> dict[str, Any]:
+    """Combine multiple anvil-train JSON payloads into one.
+
+    First-seen-wins per (op, m_bucket, n_bucket, k_bucket) cell -- mirrors
+    the inference `merge_runtime_configs` semantics. Useful for stitching
+    together sweep results from multiple runs (e.g. mxfp4 + int4 separate
+    invocations).
+
+    Args:
+        payloads: iterable of decoded JSON dicts. Schema mismatch on any
+            payload is silently skipped -- callers should validate up front
+            if strict checking is required.
+        gpu: GPU string for the merged output.
+        model: Model name for the merged output.
+
+    Returns:
+        A new payload dict (NOT a JSON string) with the same v1 shape.
+    """
+    merged_ops: dict[str, dict[str, dict[str, Any]]] = {}
+    batch = 0
+    seq = 0
+    rocm_version = ""
+    torch_version = ""
+    triton_version = ""
+    kernel_hash = ""
+
+    for payload in payloads:
+        if not isinstance(payload, dict):
+            continue
+        if payload.get("schema") != SCHEMA_VERSION:
+            continue
+        # Take the first non-empty version/hash strings encountered. The
+        # merged payload represents whichever sweep produced these values
+        # most authoritatively -- callers can override after the fact if
+        # they have a better source.
+        if not rocm_version and payload.get("rocm_version"):
+            rocm_version = str(payload["rocm_version"])
+        if not torch_version and payload.get("torch_version"):
+            torch_version = str(payload["torch_version"])
+        if not triton_version and payload.get("triton_version"):
+            triton_version = str(payload["triton_version"])
+        if not kernel_hash and payload.get("kernel_hash"):
+            kernel_hash = str(payload["kernel_hash"])
+        if not batch and payload.get("batch"):
+            try:
+                batch = int(payload["batch"])
+            except (TypeError, ValueError):
+                pass
+        if not seq and payload.get("seq"):
+            try:
+                seq = int(payload["seq"])
+            except (TypeError, ValueError):
+                pass
+
+        ops = payload.get("ops") or {}
+        if not isinstance(ops, dict):
+            continue
+        for op_name, cells in ops.items():
+            if not isinstance(cells, dict):
+                continue
+            dest = merged_ops.setdefault(op_name, {})
+            for cell_key, cell_payload in cells.items():
+                if cell_key in dest:
+                    # First-seen wins.
+                    continue
+                cfg = _coerce_payload(cell_payload) if isinstance(cell_payload, dict) else None
+                if cfg is not None:
+                    dest[cell_key] = cfg.to_dict()
+
+    return {
+        "schema": SCHEMA_VERSION,
+        "gpu": gpu,
+        "rocm_version": rocm_version,
+        "torch_version": torch_version,
+        "triton_version": triton_version,
+        "kernel_hash": kernel_hash,
+        "model": model,
+        "batch": batch,
+        "seq": seq,
+        "ops": merged_ops,
+    }

--- a/kernel_anvil/train_param_space.py
+++ b/kernel_anvil/train_param_space.py
@@ -1,0 +1,189 @@
+"""Triton config grid generator for training-kernel autotune.
+
+The training search space is structurally different from the inference GEMV
+space (`sweep.generate_configs`):
+
+- 2D output tile: BLOCK_M and BLOCK_N (not just BLOCK_N).
+- Real reduction tile: BLOCK_K up to 128 (training kernels run fp32-accum
+  fused dequant+matmul; deeper K helps amortize dequant cost).
+- GROUP_M: super-grouping for L2 cache reuse on RDNA3.
+- num_stages reaches 4 for software pipelining when LDS budget allows.
+
+We target ~30 candidates per shape after RDNA3 VGPR/LDS filtering. The base
+Cartesian product is intentionally generous (3072 raw configs); the filter
++ ranking trims it.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Iterable
+
+from kernel_anvil.rdna3 import GFX1100, GpuSpec
+
+# Base grid (per spec). These are intentionally Triton-friendly powers of two.
+_BLOCK_M_VALUES = (32, 64, 128, 256)
+_BLOCK_N_VALUES = (32, 64, 128, 256)
+_BLOCK_K_VALUES = (32, 64, 128)
+_GROUP_M_VALUES = (1, 4, 8, 16)
+_NUM_WARPS_VALUES = (4, 8)
+_NUM_STAGES_VALUES = (2, 3, 4)
+
+# Approximate per-element bytes for a fused dequant+matmul training kernel:
+# bf16/fp16 activations + fp32 accumulator + small overhead from packed weight
+# tile. The exact number depends on the kernel; we use a conservative 4 byte/el
+# average for the LDS estimate (fp32 accumulator + bf16 input).
+#
+# LDS usage estimate (bytes per workgroup):
+#   activations: BLOCK_M * BLOCK_K * 2 (bf16/fp16)
+#   weights:     BLOCK_N * BLOCK_K * 0.5..2 depending on quant (we use 1 to be
+#                generous; INT4/MXFP4 packed is 0.5; bf16 ref path is 2)
+#   stages:      multiplied by num_stages (software-pipelined double/triple
+#                buffering)
+_ACT_ELEMENT_BYTES = 2
+_WEIGHT_ELEMENT_BYTES = 1  # average for INT4/MXFP4 unpacked at fp32-accum
+# VGPR estimate: per-thread tile footprint. The accumulator dominates:
+# (BLOCK_M * BLOCK_N) / threads_per_workgroup floats. Plus operand tiles in
+# registers.
+_FP32_ACC_BYTES = 4
+_VGPR_BYTES = 4  # 1 VGPR per fp32 lane
+
+
+def _threads_per_workgroup(num_warps: int, wave_size: int = 32) -> int:
+    """Triton maps num_warps to threads via wave_size on RDNA3 (wave32)."""
+    return num_warps * wave_size
+
+
+def _estimate_lds_bytes(block_m: int, block_n: int, block_k: int, num_stages: int) -> int:
+    """Heuristic LDS-per-workgroup estimate.
+
+    The kernel double/triple-buffers operand tiles to overlap loads with
+    compute. Each stage holds one tile of activations and one tile of
+    weights.
+    """
+    a_tile = block_m * block_k * _ACT_ELEMENT_BYTES
+    b_tile = block_n * block_k * _WEIGHT_ELEMENT_BYTES
+    return (a_tile + b_tile) * max(num_stages, 1)
+
+
+def _estimate_vgpr(block_m: int, block_n: int, num_warps: int) -> int:
+    """Heuristic VGPRs-per-thread for a 2D MMA accumulator tile.
+
+    Each thread owns (BLOCK_M * BLOCK_N) / threads_per_workgroup fp32 lanes
+    of accumulator, plus a constant overhead for pointers, scales, masks.
+    """
+    threads = _threads_per_workgroup(num_warps)
+    if threads <= 0:
+        return 1024  # absurd -- will be filtered out
+    acc_per_thread = (block_m * block_n) // threads
+    overhead = 32  # pointers, scales, masks, loop counters
+    return acc_per_thread + overhead
+
+
+def _config_fits_rdna3(
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    num_warps: int,
+    num_stages: int,
+    gpu: GpuSpec,
+) -> bool:
+    """Filter configs that exceed RDNA3 VGPR or LDS budgets.
+
+    Falls back to the GFX1100 spec if `gpu` lacks one of the fields. The
+    bound is intentionally a bit pessimistic so that legitimate winners
+    survive rocm-smi-detected hardware variation.
+    """
+    lds = _estimate_lds_bytes(block_m, block_n, block_k, num_stages)
+    if lds > gpu.lds_per_cu_bytes:
+        return False
+    vgpr = _estimate_vgpr(block_m, block_n, num_warps)
+    if vgpr > gpu.vgpr_per_simd:
+        return False
+    # Triton mandates BLOCK_M >= 16 and BLOCK_N >= 16 for matmul
+    # (sub-16 tiles spill MFMA). Already enforced by our value tuples but
+    # paranoia is cheap.
+    if min(block_m, block_n, block_k) < 16:
+        return False
+    # GROUP_M cannot exceed M tiles meaningfully -- a larger value would just
+    # underutilize CUs. We don't filter on this since GROUP_M=16 is the max
+    # in the grid and still useful for very tall (M=large) kernels.
+    return True
+
+
+def _rank_key(cfg: dict) -> tuple:
+    """Heuristic ranking key for picking the top-K configs.
+
+    Bias toward 'mid-tile' candidates which are the empirical winners on
+    RDNA3 (BLOCK_M=128 BLOCK_N=64 or 128 BLOCK_K=32 or 64 from the
+    headroom benchmark). Larger tiles get higher VGPR/LDS pressure; smaller
+    tiles waste parallelism. The ranking is purely a tiebreaker for the
+    top-K cap; the actual sweep still benchmarks every kept candidate.
+    """
+    bm = cfg["BLOCK_M"]
+    bn = cfg["BLOCK_N"]
+    bk = cfg["BLOCK_K"]
+    # Distance from the empirical sweet spot (128, 64, 32). Lower is better.
+    dist = abs(bm - 128) + abs(bn - 64) + abs(bk - 32)
+    # Penalize stages=4 slightly (larger LDS pressure, marginal gains).
+    stage_pen = max(0, cfg["num_stages"] - 3) * 2
+    return (dist + stage_pen, cfg["num_warps"])
+
+
+def generate_train_configs(
+    *,
+    gpu: GpuSpec | None = None,
+    max_configs: int = 30,
+    block_m_values: Iterable[int] | None = None,
+    block_n_values: Iterable[int] | None = None,
+    block_k_values: Iterable[int] | None = None,
+    group_m_values: Iterable[int] | None = None,
+    num_warps_values: Iterable[int] | None = None,
+    num_stages_values: Iterable[int] | None = None,
+) -> list[dict]:
+    """Build the per-shape Triton config candidate list for a training sweep.
+
+    Args:
+        gpu: GPU spec used for the VGPR/LDS sanity filter. Defaults to
+            GFX1100 (7900 XTX) when None.
+        max_configs: Cap on the returned list. The default 30 matches the
+            risk register's compile-budget target (162 configs * 5 shapes
+            took ~16 min in the headroom bench; aiming for ~30 keeps
+            wallclock under ~5 min per shape).
+        block_m_values .. num_stages_values: Override the base grid. Pass
+            None to use the spec defaults. Useful for narrowing the sweep
+            during debug.
+
+    Returns:
+        A list of dicts, each carrying:
+            BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M, num_warps, num_stages.
+    """
+    gpu = gpu or GFX1100
+    bm = tuple(block_m_values) if block_m_values is not None else _BLOCK_M_VALUES
+    bn = tuple(block_n_values) if block_n_values is not None else _BLOCK_N_VALUES
+    bk = tuple(block_k_values) if block_k_values is not None else _BLOCK_K_VALUES
+    gm = tuple(group_m_values) if group_m_values is not None else _GROUP_M_VALUES
+    nw = tuple(num_warps_values) if num_warps_values is not None else _NUM_WARPS_VALUES
+    ns = tuple(num_stages_values) if num_stages_values is not None else _NUM_STAGES_VALUES
+
+    candidates: list[dict] = []
+    for block_m, block_n, block_k, group_m, num_warps, num_stages in itertools.product(
+        bm, bn, bk, gm, nw, ns
+    ):
+        if not _config_fits_rdna3(block_m, block_n, block_k, num_warps, num_stages, gpu):
+            continue
+        candidates.append(
+            {
+                "BLOCK_M": block_m,
+                "BLOCK_N": block_n,
+                "BLOCK_K": block_k,
+                "GROUP_M": group_m,
+                "num_warps": num_warps,
+                "num_stages": num_stages,
+            }
+        )
+
+    candidates.sort(key=_rank_key)
+    if max_configs and max_configs > 0:
+        candidates = candidates[:max_configs]
+    return candidates

--- a/kernel_anvil/train_shapes.py
+++ b/kernel_anvil/train_shapes.py
@@ -1,0 +1,254 @@
+"""Extract Triton-tunable GEMM shapes from a Hugging Face model config.
+
+Inference-side autotune (`gguf-optimize`) parses GGUF tensors directly to
+discover unique (N, K) projection shapes. Training has no GGUF; we walk the
+HF model config and synthesize the shapes the forward + grad-input kernels
+will see for a given (batch, seq) pair.
+
+Supported architectures:
+
+- **Dense LLaMA / Qwen3** (`LlamaConfig`, `Qwen3Config`): four forward
+  shapes per layer (q_proj, k_proj, v_proj/o_proj, gate_up_proj, down_proj
+  -- collapsed to four uniques).
+- **gpt-oss MoE** (`GptOssConfig`): attention identical to dense; experts
+  contribute irregular-M shapes flattened to a single (M, N=2*intermediate,
+  K=hidden) gate_up and (M, N=hidden, K=intermediate) down_proj. The bucket
+  scheme handles the irregular-M side.
+
+The output is the deduplicated set of (op, M, N, K) tuples, where `op`
+spans the requested ops list (default: forward + grad-input for both
+quants).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable, Sequence
+
+DEFAULT_OPS: tuple[str, ...] = (
+    "mxfp4_fwd",
+    "mxfp4_grad_input",
+    "int4_fwd",
+    "int4_grad_input",
+)
+
+
+def _load_hf_config(model_id_or_config) -> object:
+    """Load an HF AutoConfig, with graceful fallback for offline / cache.
+
+    Returns the config object directly if already an instance. Otherwise
+    invokes `transformers.AutoConfig.from_pretrained(..., trust_remote_code
+    =True)`. If the fetch fails (no network, private repo, missing local
+    cache), retries with `local_files_only=True` to lean on the user's
+    huggingface cache. If even that misses, raises a clear RuntimeError so
+    the CLI can surface a useful message.
+    """
+    if model_id_or_config is None:
+        raise ValueError("model_id_or_config must not be None")
+    # Allow passing a pre-built config object (test fixture, custom config).
+    if not isinstance(model_id_or_config, (str, os.PathLike)):
+        return model_id_or_config
+
+    try:
+        from transformers import AutoConfig  # type: ignore
+    except ImportError as exc:
+        raise RuntimeError(
+            "transformers is not installed; install with `pip install transformers`"
+            " or pass a pre-built config object."
+        ) from exc
+
+    model_id = str(model_id_or_config)
+    last_err: Exception | None = None
+    for kwargs in ({"trust_remote_code": True}, {"trust_remote_code": True, "local_files_only": True}):
+        try:
+            return AutoConfig.from_pretrained(model_id, **kwargs)
+        except Exception as exc:  # network errors, gated repos, missing cache
+            last_err = exc
+    raise RuntimeError(
+        f"Could not load HF config for {model_id!r} (network and local cache both failed): {last_err}"
+    )
+
+
+def _arch_name(cfg) -> str:
+    """Best-effort architecture name string for routing.
+
+    Real `transformers` config objects expose their class as
+    `type(cfg).__name__` (e.g. ``LlamaConfig``). For test fixtures we also
+    accept a stashed ``__class__`` attribute pointing at a class object
+    whose name carries the arch hint -- this lets us exercise dispatch
+    without constructing real transformers configs.
+    """
+    real = type(cfg).__name__
+    if real and real not in ("SimpleNamespace", "object", "dict"):
+        return real
+    stash = getattr(cfg, "__class__", None)
+    stash_name = getattr(stash, "__name__", "") if stash is not None else ""
+    if stash_name and stash_name not in ("SimpleNamespace", "object", "dict", "type"):
+        return stash_name
+    archs = getattr(cfg, "architectures", None) or []
+    if archs:
+        return str(archs[0])
+    # model_type is a transformers.PretrainedConfig field that survives
+    # most subclassing patterns.
+    return str(getattr(cfg, "model_type", "") or "")
+
+
+def _is_llama_like(cfg) -> bool:
+    name = _arch_name(cfg).lower()
+    return "llama" in name or "qwen" in name or "mistral" in name or "phi" in name
+
+
+def _is_gpt_oss(cfg) -> bool:
+    name = _arch_name(cfg).lower()
+    return "gptoss" in name or "gpt_oss" in name or "gpt-oss" in name
+
+
+def _dense_shapes(cfg, M: int) -> list[tuple[int, int, int]]:
+    """Forward GEMM shapes for a dense LLaMA/Qwen-style decoder layer.
+
+    Per-layer ops:
+        q_proj:       N=hidden,             K=hidden
+        k_proj/v_proj:N=num_kv_heads*head_dim, K=hidden  (GQA may collapse to one)
+        o_proj:       N=hidden,             K=hidden
+        gate/up_proj: N=intermediate,       K=hidden
+        down_proj:    N=hidden,             K=intermediate
+
+    The unique shapes (deduped) for a single forward pass:
+        (M, hidden, hidden)               -- q_proj, o_proj
+        (M, kv_dim, hidden)               -- k_proj, v_proj when kv_dim != hidden
+        (M, intermediate, hidden)         -- gate, up
+        (M, hidden, intermediate)         -- down
+    """
+    hidden = int(getattr(cfg, "hidden_size"))
+    intermediate = int(getattr(cfg, "intermediate_size", hidden * 4))
+    num_heads = int(getattr(cfg, "num_attention_heads", 1))
+    num_kv_heads = int(
+        getattr(cfg, "num_key_value_heads", num_heads) or num_heads
+    )
+    head_dim = int(getattr(cfg, "head_dim", hidden // max(num_heads, 1)))
+    kv_dim = num_kv_heads * head_dim
+
+    shapes: list[tuple[int, int, int]] = [
+        (M, hidden, hidden),
+        (M, intermediate, hidden),
+        (M, hidden, intermediate),
+    ]
+    if kv_dim and kv_dim != hidden:
+        shapes.append((M, kv_dim, hidden))
+    return shapes
+
+
+def _gpt_oss_shapes(cfg, M: int) -> list[tuple[int, int, int]]:
+    """Forward GEMM shapes for a gpt-oss MoE decoder layer.
+
+    Attention shapes are dense-equivalent. Expert shapes are flattened across
+    experts -- we treat the tokens-per-expert as irregular-M; the 3D bucket
+    scheme handles that. The MoE-specific shapes are:
+
+        gate_up_proj: N = 2 * intermediate, K = hidden
+        down_proj:    N = hidden,           K = intermediate
+
+    (`2 *` because gate_up packs gate || up into a single weight tile.)
+    """
+    hidden = int(getattr(cfg, "hidden_size"))
+    intermediate = int(getattr(cfg, "intermediate_size", hidden * 4))
+    num_experts = int(getattr(cfg, "num_local_experts", getattr(cfg, "num_experts", 1)) or 1)
+    top_k = int(getattr(cfg, "num_experts_per_tok", 1) or 1)
+
+    # Dense attention shapes (q,k,v,o) reuse the dense logic.
+    attn_shapes = _dense_shapes(cfg, M)
+
+    # Expert M: each token is routed to top_k experts; per expert the M is
+    # roughly M * top_k / num_experts. We round up to nearest power of two
+    # to keep the bucket count small. The 3D bucket scheme buckets the
+    # irregular-M cases together, so the actual runtime M can vary.
+    if num_experts > 0 and top_k > 0:
+        per_expert_m = max(1, (M * top_k + num_experts - 1) // num_experts)
+    else:
+        per_expert_m = M
+
+    expert_shapes = [
+        (per_expert_m, 2 * intermediate, hidden),  # gate_up
+        (per_expert_m, hidden, intermediate),      # down
+    ]
+    return attn_shapes + expert_shapes
+
+
+def _shapes_for_config(cfg, M: int) -> list[tuple[int, int, int]]:
+    """Dispatch shape extraction based on architecture string."""
+    if _is_gpt_oss(cfg):
+        return _gpt_oss_shapes(cfg, M)
+    if _is_llama_like(cfg):
+        return _dense_shapes(cfg, M)
+    # Generic fallback: assume LLaMA-like attribute names. transformers is
+    # consistent enough that hidden_size + intermediate_size are present on
+    # almost every decoder config.
+    if hasattr(cfg, "hidden_size") and hasattr(cfg, "intermediate_size"):
+        return _dense_shapes(cfg, M)
+    raise ValueError(
+        f"Unsupported HF config: {_arch_name(cfg)} -- add a shape extractor"
+        " or pass a known architecture (LlamaConfig, Qwen3Config, GptOssConfig)."
+    )
+
+
+def extract_shapes(
+    model_id_or_config,
+    *,
+    batch: int,
+    seq: int,
+    ops: Sequence[str] | None = None,
+) -> list[tuple[str, int, int, int]]:
+    """Return the deduped list of (op, M, N, K) tuples for the given model.
+
+    Args:
+        model_id_or_config: HF model id (string), local path, or pre-built
+            transformers config object.
+        batch: Per-device batch size used at training time.
+        seq: Sequence length used at training time.
+        ops: Iterable of op names. Defaults to all four (mxfp4 fwd/grad-in,
+            int4 fwd/grad-in). The same (M, N, K) shape is emitted once per
+            requested op.
+
+    Returns:
+        Deduplicated list of (op_name, M, N, K) tuples in stable order
+        (sorted on the tuple).
+    """
+    if batch <= 0 or seq <= 0:
+        raise ValueError(f"batch and seq must be positive (got batch={batch}, seq={seq})")
+    if ops is None:
+        op_list = list(DEFAULT_OPS)
+    else:
+        op_list = list(ops)
+        if not op_list:
+            raise ValueError("ops must be a non-empty iterable")
+
+    cfg = _load_hf_config(model_id_or_config)
+    M = batch * seq
+    raw_shapes = _shapes_for_config(cfg, M)
+
+    seen: set[tuple[str, int, int, int]] = set()
+    out: list[tuple[str, int, int, int]] = []
+    for op in op_list:
+        for m, n, k in raw_shapes:
+            if m <= 0 or n <= 0 or k <= 0:
+                continue
+            key = (op, int(m), int(n), int(k))
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(key)
+    out.sort()
+    return out
+
+
+def model_basename(model_id: str) -> str:
+    """Best-effort model basename for cache-path construction.
+
+    `Qwen/Qwen3-8B` -> `Qwen3-8B`. Local paths use the directory stem.
+    """
+    if not model_id:
+        return "model"
+    s = str(model_id).rstrip("/")
+    if "/" in s:
+        return s.split("/")[-1]
+    return s

--- a/kernel_anvil/verify.py
+++ b/kernel_anvil/verify.py
@@ -48,9 +48,47 @@ def _benchmark(fn, config: dict, warmup: int, runs: int) -> float:
         return sorted(times)[len(times) // 2]
 
 
+def _pick_tensor(value, output_index: int):
+    """Pull a single tensor out of a runner's output.
+
+    Training kernels (e.g. grad-input) may return a tuple (dX, dW, ...) or a
+    list/dict of tensors. The sweep machinery only allclose-checks one
+    output at a time; ``output_index`` picks which slot to validate.
+    """
+    if isinstance(value, torch.Tensor):
+        return value
+    if isinstance(value, (list, tuple)):
+        if not value:
+            raise ValueError("kernel_fn returned empty tuple/list")
+        idx = output_index if 0 <= output_index < len(value) else 0
+        item = value[idx]
+        if not isinstance(item, torch.Tensor):
+            raise TypeError(
+                f"kernel_fn output[{idx}] must be a torch.Tensor, got {type(item).__name__}"
+            )
+        return item
+    if isinstance(value, dict):
+        # Pick by integer index over sorted keys for determinism. Strings
+        # like "dX"/"dW" don't have a natural int index; document this.
+        keys = sorted(value.keys())
+        if not keys:
+            raise ValueError("kernel_fn returned empty dict")
+        idx = output_index if 0 <= output_index < len(keys) else 0
+        item = value[keys[idx]]
+        if not isinstance(item, torch.Tensor):
+            raise TypeError(
+                f"kernel_fn output[{keys[idx]!r}] must be a torch.Tensor"
+            )
+        return item
+    raise TypeError(
+        f"kernel_fn must return a Tensor, tuple/list of Tensors, or dict of Tensors;"
+        f" got {type(value).__name__}"
+    )
+
+
 def verify_and_bench(
     kernel_fn,
-    reference_output: torch.Tensor,
+    reference_output,
     config: dict,
     warmup: int = 5,
     runs: int = 10,
@@ -58,12 +96,15 @@ def verify_and_bench(
     rtol: float = 1e-2,
     data_bytes: int | None = None,
     baseline_latency_us: float | None = None,
+    output_index: int = 0,
 ) -> VerifyResult:
     """Run kernel with config, verify correctness, benchmark timing.
 
     Args:
-        kernel_fn: callable(config) -> output tensor
-        reference_output: expected output tensor to compare against
+        kernel_fn: callable(config) -> output tensor or tuple/list/dict of tensors
+        reference_output: expected output (tensor, tuple, list, or dict).
+            Must match the kernel's return shape; ``output_index`` selects
+            which slot to allclose-check when multiple are returned.
         config: config dict passed to kernel_fn
         warmup: number of warmup iterations before timing
         runs: number of timed iterations
@@ -71,13 +112,17 @@ def verify_and_bench(
         rtol: relative tolerance for correctness check
         data_bytes: total bytes moved (for bandwidth calculation)
         baseline_latency_us: baseline latency for speedup calculation
+        output_index: when the kernel returns a tuple/list/dict, which slot
+            to use for the correctness check (default 0).
     """
     # Run the kernel to get output for correctness check
-    output = kernel_fn(config)
+    raw_output = kernel_fn(config)
+    output = _pick_tensor(raw_output, output_index)
+    ref_tensor = _pick_tensor(reference_output, output_index)
 
     # Check correctness
-    correct = torch.allclose(output, reference_output, atol=atol, rtol=rtol)
-    max_diff = (output - reference_output).abs().max().item()
+    correct = torch.allclose(output, ref_tensor, atol=atol, rtol=rtol)
+    max_diff = (output - ref_tensor).abs().max().item()
 
     # Benchmark
     latency_us = _benchmark(kernel_fn, config, warmup, runs)

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -1,0 +1,222 @@
+"""Tests for the `kernel-anvil train-optimize` CLI subcommand.
+
+These tests exercise the JSON pipeline end-to-end without requiring a GPU
+or transformers. The HF shape extractor is monkey-patched to a stub, and
+``--dry-run`` skips the runner sweep entirely.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from kernel_anvil import cli
+
+
+PROJ_ROOT = Path(__file__).parent.parent
+
+
+# ---------------------------------------------------------------------------
+# argparse plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestTrainOptimizeArgs:
+    def test_help_via_subprocess(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "kernel_anvil.cli", "train-optimize", "--help"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode == 0
+        assert "train-optimize" in result.stdout
+        assert "--quant" in result.stdout
+        assert "--batch" in result.stdout
+        assert "--seq" in result.stdout
+        assert "--dry-run" in result.stdout
+
+    def test_missing_model_arg_fails(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "kernel_anvil.cli", "train-optimize",
+             "--quant", "mxfp4", "--batch", "1", "--seq", "4096", "--dry-run"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode != 0
+
+    def test_missing_quant_fails(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "kernel_anvil.cli", "train-optimize",
+             "Qwen3-8B", "--batch", "1", "--seq", "4096", "--dry-run"],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# end-to-end dry-run
+# ---------------------------------------------------------------------------
+
+
+def _stub_shapes(model_id_or_config, *, batch: int, seq: int, ops=None):
+    """Replacement for extract_shapes -- returns deterministic Qwen3-8B-ish set."""
+    M = batch * seq
+    base = [
+        (M, 4096, 4096),
+        (M, 12288, 4096),
+        (M, 4096, 12288),
+        (M, 1024, 4096),
+    ]
+    op_list = list(ops) if ops else ["mxfp4_fwd", "mxfp4_grad_input"]
+    out = []
+    for op in op_list:
+        for m, n, k in base:
+            out.append((op, m, n, k))
+    return out
+
+
+class TestTrainOptimizeDryRun:
+    def test_writes_json_to_default_path(self, tmp_path, monkeypatch):
+        # Force a deterministic cache root by overriding HOME
+        monkeypatch.setenv("HOME", str(tmp_path))
+        # Stub shape extraction so we don't need transformers
+        monkeypatch.setattr("kernel_anvil.train_shapes.extract_shapes", _stub_shapes)
+        # Run the CLI
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "train-optimize", "Qwen3-8B",
+            "--quant", "mxfp4", "--batch", "1", "--seq", "4096", "--dry-run",
+        ])
+        cli.main()
+        # Cache path should be ~/.cache/anvil-train/<gpu>/Qwen3-8B-mxfp4-b1s4096.json
+        cache_root = tmp_path / ".cache" / "anvil-train"
+        assert cache_root.exists()
+        # Find the GPU subdir (e.g. gfx1100)
+        gpu_dirs = list(cache_root.iterdir())
+        assert gpu_dirs, "expected a GPU subdir under ~/.cache/anvil-train"
+        json_files = list(gpu_dirs[0].glob("*.json"))
+        assert json_files, "expected a JSON file in the GPU subdir"
+        payload = json.loads(json_files[0].read_text())
+        assert payload["schema"] == "anvil-train/v1"
+        assert payload["model"] == "Qwen3-8B"
+        assert payload["batch"] == 1
+        assert payload["seq"] == 4096
+        # Dry-run uses placeholder ops
+        assert "mxfp4_fwd" in payload["ops"]
+        assert "mxfp4_grad_input" in payload["ops"]
+
+    def test_writes_json_to_explicit_output(self, tmp_path, monkeypatch):
+        out_path = tmp_path / "custom.json"
+        monkeypatch.setattr("kernel_anvil.train_shapes.extract_shapes", _stub_shapes)
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "train-optimize", "Qwen3-8B",
+            "--quant", "mxfp4", "--batch", "1", "--seq", "4096",
+            "--dry-run", "--output", str(out_path),
+        ])
+        cli.main()
+        assert out_path.exists()
+        payload = json.loads(out_path.read_text())
+        assert payload["schema"] == "anvil-train/v1"
+
+    def test_dry_run_payload_has_placeholder_configs(self, tmp_path, monkeypatch):
+        out_path = tmp_path / "out.json"
+        monkeypatch.setattr("kernel_anvil.train_shapes.extract_shapes", _stub_shapes)
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "train-optimize", "Qwen3-8B",
+            "--quant", "mxfp4", "--batch", "1", "--seq", "4096",
+            "--dry-run", "--output", str(out_path),
+        ])
+        cli.main()
+        payload = json.loads(out_path.read_text())
+        # Every cell must have the six required keys.
+        for op, cells in payload["ops"].items():
+            for cell, body in cells.items():
+                for k in ("BLOCK_M", "BLOCK_N", "BLOCK_K", "GROUP_M",
+                          "num_warps", "num_stages"):
+                    assert k in body, f"missing {k} in {op}/{cell}"
+
+    def test_dry_run_int4_op_set(self, tmp_path, monkeypatch):
+        out_path = tmp_path / "int4.json"
+        monkeypatch.setattr("kernel_anvil.train_shapes.extract_shapes", _stub_shapes)
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "train-optimize", "Qwen3-8B",
+            "--quant", "int4", "--batch", "1", "--seq", "4096",
+            "--dry-run", "--output", str(out_path),
+        ])
+        cli.main()
+        payload = json.loads(out_path.read_text())
+        # int4 quant -> default ops should be int4_fwd + int4_grad_input
+        assert any(op.startswith("int4") for op in payload["ops"])
+
+    def test_extract_shapes_failure_exits_clean(self, tmp_path, monkeypatch):
+        def boom(*a, **kw):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr("kernel_anvil.train_shapes.extract_shapes", boom)
+        out_path = tmp_path / "out.json"
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "train-optimize", "Qwen3-8B",
+            "--quant", "mxfp4", "--batch", "1", "--seq", "4096",
+            "--dry-run", "--output", str(out_path),
+        ])
+        with pytest.raises(SystemExit) as exc:
+            cli.main()
+        assert exc.value.code == 1
+
+    def test_atomic_write_no_tmp_left(self, tmp_path, monkeypatch):
+        out_path = tmp_path / "out.json"
+        monkeypatch.setattr("kernel_anvil.train_shapes.extract_shapes", _stub_shapes)
+        monkeypatch.setattr(sys, "argv", [
+            "kernel-anvil", "train-optimize", "Qwen3-8B",
+            "--quant", "mxfp4", "--batch", "1", "--seq", "4096",
+            "--dry-run", "--output", str(out_path),
+        ])
+        cli.main()
+        leftover = [p.name for p in tmp_path.iterdir() if p.name.endswith(".json.tmp")]
+        assert leftover == [], f"atomic write left tempfiles: {leftover}"
+
+
+# ---------------------------------------------------------------------------
+# train-optimize parameter space sanity (smoke test)
+# ---------------------------------------------------------------------------
+
+
+class TestTrainParamSpace:
+    def test_generates_at_most_max_configs(self):
+        from kernel_anvil.train_param_space import generate_train_configs
+
+        configs = generate_train_configs(max_configs=10)
+        assert len(configs) <= 10
+        assert all(isinstance(c, dict) for c in configs)
+        for c in configs:
+            for k in ("BLOCK_M", "BLOCK_N", "BLOCK_K", "GROUP_M",
+                      "num_warps", "num_stages"):
+                assert k in c
+
+    def test_default_returns_about_30(self):
+        from kernel_anvil.train_param_space import generate_train_configs
+
+        configs = generate_train_configs()
+        # Cap is 30 by default; the filter MAY trim further but the cap is
+        # the upper bound.
+        assert 1 <= len(configs) <= 30
+
+    def test_rdna3_filter_drops_oversize_configs(self):
+        from kernel_anvil.train_param_space import generate_train_configs
+        from kernel_anvil.rdna3 import GFX1100
+
+        # Force a tiny base grid that will all overflow LDS budget.
+        configs = generate_train_configs(
+            gpu=GFX1100,
+            block_m_values=[256],
+            block_n_values=[256],
+            block_k_values=[128],
+            group_m_values=[8],
+            num_warps_values=[8],
+            num_stages_values=[4],
+        )
+        # 256 * 128 * 2 + 256 * 128 * 1 = 65536 + 32768 = 98304 *4 stages
+        # >> 98304 LDS budget, so should be filtered.
+        assert configs == []

--- a/tests/test_train_codegen.py
+++ b/tests/test_train_codegen.py
@@ -1,0 +1,343 @@
+"""Tests for the anvil-train v1 JSON code generator."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kernel_anvil.train_codegen import (
+    BUCKET_BOUNDARIES,
+    KNOWN_OPS,
+    NUM_BUCKETS,
+    SCHEMA_VERSION,
+    TrainShapeConfig,
+    bucket_index_3d,
+    build_op_table,
+    generate_train_runtime_config,
+    merge_train_runtime_configs,
+)
+
+
+# ---------------------------------------------------------------------------
+# bucket_index_3d
+# ---------------------------------------------------------------------------
+
+
+class TestBucketIndex3D:
+    def test_below_first_boundary_in_all_axes(self):
+        assert bucket_index_3d(1, 1, 1) == (0, 0, 0)
+        assert bucket_index_3d(1024, 1024, 1024) == (0, 0, 0)
+
+    def test_exact_boundaries_per_axis(self):
+        # Each axis uses identical boundaries; bucket i is reached at
+        # value == BUCKET_BOUNDARIES[i].
+        for i, boundary in enumerate(BUCKET_BOUNDARIES):
+            assert bucket_index_3d(boundary, boundary, boundary) == (i, i, i)
+
+    def test_just_above_boundaries(self):
+        assert bucket_index_3d(1025, 1, 1) == (1, 0, 0)
+        assert bucket_index_3d(1, 4097, 1) == (0, 2, 0)
+        assert bucket_index_3d(1, 1, 16385) == (0, 0, 4)
+
+    def test_overflow_to_last_bucket(self):
+        big = BUCKET_BOUNDARIES[-1] * 100
+        assert bucket_index_3d(big, big, big) == (
+            len(BUCKET_BOUNDARIES),
+            len(BUCKET_BOUNDARIES),
+            len(BUCKET_BOUNDARIES),
+        )
+
+    def test_independent_axes(self):
+        # Boundaries are (1024, 4096, 8192, 16384). 512 -> bucket 0,
+        # 8192 (== boundary index 2) -> bucket 2.
+        assert bucket_index_3d(8192, 512, 8192) == (2, 0, 2)
+
+
+class TestNumBuckets:
+    def test_num_buckets_matches_boundary_count_plus_one(self):
+        assert NUM_BUCKETS == len(BUCKET_BOUNDARIES) + 1
+
+
+# ---------------------------------------------------------------------------
+# TrainShapeConfig
+# ---------------------------------------------------------------------------
+
+
+class TestTrainShapeConfig:
+    def test_required_fields_only(self):
+        cfg = TrainShapeConfig(
+            BLOCK_M=128, BLOCK_N=64, BLOCK_K=32,
+            GROUP_M=8, num_warps=8, num_stages=4,
+        )
+        d = cfg.to_dict()
+        assert d == {
+            "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+            "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+        }
+
+    def test_optional_fields_round_trip(self):
+        cfg = TrainShapeConfig(
+            BLOCK_M=128, BLOCK_N=64, BLOCK_K=32,
+            GROUP_M=8, num_warps=8, num_stages=4,
+            speedup_vs_baseline=1.42, profiled_us=18.4,
+        )
+        d = cfg.to_dict()
+        assert d["speedup_vs_baseline"] == 1.42
+        assert d["profiled_us"] == 18.4
+
+    def test_frozen(self):
+        cfg = TrainShapeConfig(
+            BLOCK_M=128, BLOCK_N=64, BLOCK_K=32,
+            GROUP_M=8, num_warps=8, num_stages=4,
+        )
+        with pytest.raises(AttributeError):
+            cfg.BLOCK_M = 256
+
+
+# ---------------------------------------------------------------------------
+# build_op_table
+# ---------------------------------------------------------------------------
+
+
+class TestBuildOpTable:
+    def test_empty(self):
+        assert build_op_table({}) == {}
+
+    def test_single_entry_lands_in_correct_cell(self):
+        configs = {
+            ("mxfp4_fwd", 4096, 4096, 4096): {
+                "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+                "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+            },
+        }
+        table = build_op_table(configs)
+        assert "mxfp4_fwd" in table
+        # 4096 -> bucket 1 on each axis (boundary == 4096)
+        cell_key = "1,1,1"
+        assert cell_key in table["mxfp4_fwd"]
+        assert table["mxfp4_fwd"][cell_key]["BLOCK_M"] == 128
+
+    def test_multiple_ops_isolated(self):
+        configs = {
+            ("mxfp4_fwd", 4096, 4096, 4096): {
+                "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+                "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+            },
+            ("int4_fwd", 4096, 4096, 4096): {
+                "BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64,
+                "GROUP_M": 4, "num_warps": 4, "num_stages": 2,
+            },
+        }
+        table = build_op_table(configs)
+        assert table["mxfp4_fwd"]["1,1,1"]["BLOCK_M"] == 128
+        assert table["int4_fwd"]["1,1,1"]["BLOCK_M"] == 64
+
+    def test_first_seen_wins_without_priority(self):
+        configs = {
+            ("mxfp4_fwd", 3000, 3000, 3000): {
+                "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+                "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+            },
+            ("mxfp4_fwd", 4000, 4000, 4000): {
+                "BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64,
+                "GROUP_M": 4, "num_warps": 4, "num_stages": 2,
+            },
+        }
+        table = build_op_table(configs)
+        # Both shapes map to bucket cell 1,1,1; first inserted wins.
+        assert table["mxfp4_fwd"]["1,1,1"]["BLOCK_M"] == 128
+
+    def test_priority_picks_higher(self):
+        configs = {
+            ("mxfp4_fwd", 3000, 3000, 3000): {
+                "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+                "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+            },
+            ("mxfp4_fwd", 4000, 4000, 4000): {
+                "BLOCK_M": 64, "BLOCK_N": 128, "BLOCK_K": 64,
+                "GROUP_M": 4, "num_warps": 4, "num_stages": 2,
+            },
+        }
+        priorities = {
+            ("mxfp4_fwd", 3000, 3000, 3000): 100,
+            ("mxfp4_fwd", 4000, 4000, 4000): 200,
+        }
+        table = build_op_table(configs, priorities=priorities)
+        # Higher-priority entry wins.
+        assert table["mxfp4_fwd"]["1,1,1"]["BLOCK_M"] == 64
+
+    def test_malformed_payload_silently_skipped(self):
+        configs = {
+            ("mxfp4_fwd", 4096, 4096, 4096): {
+                "BLOCK_M": 128,  # missing other required fields
+            },
+        }
+        table = build_op_table(configs)
+        assert table == {}
+
+    def test_non_tuple_key_silently_skipped(self):
+        configs = {
+            "not a tuple": {
+                "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+                "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+            },
+        }
+        table = build_op_table(configs)
+        assert table == {}
+
+    def test_zero_or_negative_dims_skipped(self):
+        configs = {
+            ("mxfp4_fwd", 0, 4096, 4096): {
+                "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+                "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+            },
+            ("mxfp4_fwd", 4096, -1, 4096): {
+                "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+                "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+            },
+        }
+        table = build_op_table(configs)
+        assert table == {}
+
+
+# ---------------------------------------------------------------------------
+# generate_train_runtime_config
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateTrainRuntimeConfig:
+    def _sample_configs(self):
+        return {
+            ("mxfp4_fwd", 4096, 4096, 4096): {
+                "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+                "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+                "speedup_vs_baseline": 1.33, "profiled_us": 18.4,
+            },
+            ("int4_fwd", 8192, 4096, 4096): {
+                "BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64,
+                "GROUP_M": 4, "num_warps": 4, "num_stages": 3,
+            },
+        }
+
+    def test_top_level_fields(self):
+        text = generate_train_runtime_config(
+            self._sample_configs(),
+            gpu="gfx1100",
+            model="Qwen3-8B",
+            batch=1,
+            seq=4096,
+            rocm_version="7.1",
+            torch_version="2.10.0+rocm7.1",
+            triton_version="3.6.0",
+            kernel_hash="sha256:cafe",
+        )
+        payload = json.loads(text)
+        assert payload["schema"] == SCHEMA_VERSION
+        assert payload["gpu"] == "gfx1100"
+        assert payload["model"] == "Qwen3-8B"
+        assert payload["batch"] == 1
+        assert payload["seq"] == 4096
+        assert payload["rocm_version"] == "7.1"
+        assert payload["torch_version"] == "2.10.0+rocm7.1"
+        assert payload["triton_version"] == "3.6.0"
+        assert payload["kernel_hash"] == "sha256:cafe"
+
+    def test_ops_keyed_correctly(self):
+        text = generate_train_runtime_config(
+            self._sample_configs(),
+            gpu="gfx1100", model="Qwen3-8B", batch=1, seq=4096,
+        )
+        payload = json.loads(text)
+        assert "mxfp4_fwd" in payload["ops"]
+        assert "int4_fwd" in payload["ops"]
+        # 4096 -> bucket 1; 8192 -> bucket 2 (boundaries 1024, 4096, 8192, 16384)
+        assert "1,1,1" in payload["ops"]["mxfp4_fwd"]
+        assert "2,1,1" in payload["ops"]["int4_fwd"]
+
+    def test_optional_fields_round_trip(self):
+        text = generate_train_runtime_config(
+            self._sample_configs(),
+            gpu="gfx1100", model="Qwen3-8B", batch=1, seq=4096,
+        )
+        payload = json.loads(text)
+        cell = payload["ops"]["mxfp4_fwd"]["1,1,1"]
+        assert cell["speedup_vs_baseline"] == pytest.approx(1.33)
+        assert cell["profiled_us"] == pytest.approx(18.4)
+
+    def test_known_ops_constant(self):
+        # Sanity: the contract calls out exactly four well-known ops.
+        assert KNOWN_OPS == (
+            "mxfp4_fwd",
+            "mxfp4_grad_input",
+            "int4_fwd",
+            "int4_grad_input",
+        )
+
+
+# ---------------------------------------------------------------------------
+# merge_train_runtime_configs
+# ---------------------------------------------------------------------------
+
+
+class TestMergeTrainRuntimeConfigs:
+    def _payload(self, *cells):
+        ops: dict = {}
+        for op, cell, body in cells:
+            ops.setdefault(op, {})[cell] = body
+        return {
+            "schema": SCHEMA_VERSION,
+            "gpu": "gfx1100",
+            "model": "test",
+            "batch": 1,
+            "seq": 4096,
+            "rocm_version": "7.1",
+            "torch_version": "2.10.0",
+            "triton_version": "3.6.0",
+            "kernel_hash": "sha256:abc",
+            "ops": ops,
+        }
+
+    def _body(self):
+        return {
+            "BLOCK_M": 128, "BLOCK_N": 64, "BLOCK_K": 32,
+            "GROUP_M": 8, "num_warps": 8, "num_stages": 4,
+        }
+
+    def test_empty_inputs(self):
+        merged = merge_train_runtime_configs([], gpu="gfx1100", model="x")
+        assert merged["schema"] == SCHEMA_VERSION
+        assert merged["ops"] == {}
+
+    def test_disjoint_cells_unioned(self):
+        a = self._payload(("mxfp4_fwd", "1,1,1", self._body()))
+        b = self._payload(("mxfp4_fwd", "2,2,2", self._body()))
+        merged = merge_train_runtime_configs([a, b], gpu="gfx1100", model="m")
+        assert "1,1,1" in merged["ops"]["mxfp4_fwd"]
+        assert "2,2,2" in merged["ops"]["mxfp4_fwd"]
+
+    def test_first_seen_wins_on_collision(self):
+        win = dict(self._body(), BLOCK_M=128)
+        lose = dict(self._body(), BLOCK_M=64)
+        a = self._payload(("mxfp4_fwd", "1,1,1", win))
+        b = self._payload(("mxfp4_fwd", "1,1,1", lose))
+        merged = merge_train_runtime_configs([a, b], gpu="gfx1100", model="m")
+        assert merged["ops"]["mxfp4_fwd"]["1,1,1"]["BLOCK_M"] == 128
+
+    def test_skips_wrong_schema(self):
+        # An "anvil-train/v999" payload must be ignored entirely.
+        a = self._payload(("mxfp4_fwd", "1,1,1", self._body()))
+        a["schema"] = "anvil-train/v999"
+        merged = merge_train_runtime_configs([a], gpu="gfx1100", model="m")
+        assert merged["ops"] == {}
+
+    def test_skips_non_dict_payload(self):
+        merged = merge_train_runtime_configs(
+            [None, "junk", 42], gpu="gfx1100", model="m",
+        )
+        assert merged["ops"] == {}
+
+    def test_skips_malformed_cells(self):
+        a = self._payload(("mxfp4_fwd", "1,1,1", "not a dict"))
+        merged = merge_train_runtime_configs([a], gpu="gfx1100", model="m")
+        assert merged["ops"].get("mxfp4_fwd", {}) == {}

--- a/tests/test_train_shapes.py
+++ b/tests/test_train_shapes.py
@@ -1,0 +1,189 @@
+"""Tests for HF-config -> training-shape extraction.
+
+We DO NOT hit the network. Tests use stand-in config objects whose
+attribute names match the transformers config classes (LlamaConfig,
+Qwen3Config, GptOssConfig). The extractor walks attribute names rather
+than isinstance checks, so a bare object with the right fields is enough
+to exercise the shape math.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kernel_anvil.train_shapes import (
+    DEFAULT_OPS,
+    extract_shapes,
+    model_basename,
+)
+
+
+def _make_config(class_name: str, **fields):
+    """Build a stand-in config object whose class name drives dispatch.
+
+    We can't use SimpleNamespace because its constructor stores
+    ``__class__`` as a plain attribute -- ``type(obj).__name__`` is still
+    'SimpleNamespace'. A dynamically-created class gets us a real
+    ``type(obj).__name__`` that the extractor walks.
+    """
+    cls = type(class_name, (), {})
+    obj = cls()
+    for k, v in fields.items():
+        setattr(obj, k, v)
+    return obj
+
+
+def _qwen3_8b_config():
+    return _make_config(
+        "Qwen3Config",
+        hidden_size=4096,
+        intermediate_size=12288,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=128,
+    )
+
+
+def _llama_8b_config():
+    return _make_config(
+        "LlamaConfig",
+        hidden_size=4096,
+        intermediate_size=14336,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=128,
+    )
+
+
+def _gpt_oss_20b_config():
+    """gpt-oss-20b MoE config stand-in."""
+    return _make_config(
+        "GptOssConfig",
+        hidden_size=2880,
+        intermediate_size=2880,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=64,
+        num_local_experts=32,
+        num_experts_per_tok=4,
+    )
+
+
+# ---------------------------------------------------------------------------
+# extract_shapes
+# ---------------------------------------------------------------------------
+
+
+class TestExtractShapesQwen3:
+    def test_default_ops_emit_all_four(self):
+        cfg = _qwen3_8b_config()
+        shapes = extract_shapes(cfg, batch=1, seq=4096)
+        ops = {op for op, _, _, _ in shapes}
+        assert ops == set(DEFAULT_OPS)
+
+    def test_unique_dense_shapes(self):
+        cfg = _qwen3_8b_config()
+        shapes = extract_shapes(cfg, batch=1, seq=4096, ops=["mxfp4_fwd"])
+        # Pull out (M, N, K) for the single op
+        mnk = sorted({(M, N, K) for _, M, N, K in shapes})
+        # Expected: q_proj/o_proj (4096, 4096), gate/up (4096, 12288, 4096),
+        # down (4096, 4096, 12288), kv (4096, 1024, 4096) since
+        # 8 kv-heads * 128 head_dim = 1024.
+        assert (4096, 4096, 4096) in mnk
+        assert (4096, 12288, 4096) in mnk
+        assert (4096, 4096, 12288) in mnk
+        assert (4096, 1024, 4096) in mnk
+
+    def test_M_scales_with_batch_and_seq(self):
+        cfg = _qwen3_8b_config()
+        shapes = extract_shapes(cfg, batch=2, seq=2048, ops=["mxfp4_fwd"])
+        # M should always be batch*seq = 4096 here; same numeric M as above.
+        for _, M, _, _ in shapes:
+            assert M == 4096
+
+    def test_dedup(self):
+        cfg = _qwen3_8b_config()
+        shapes = extract_shapes(cfg, batch=1, seq=4096)
+        # Should be deduplicated
+        assert len(shapes) == len(set(shapes))
+
+
+class TestExtractShapesGptOss:
+    def test_moe_emits_gate_up_and_down(self):
+        cfg = _gpt_oss_20b_config()
+        shapes = extract_shapes(cfg, batch=1, seq=2048, ops=["mxfp4_fwd"])
+        mnk = {(M, N, K) for _, M, N, K in shapes}
+        # gate_up: N = 2 * intermediate = 5760; down: N = hidden = 2880
+        assert any(N == 5760 and K == 2880 for _, N, K in mnk) or any(
+            n == 5760 and k == 2880 for _, n, k in mnk
+        )
+        assert any(N == 2880 and K == 2880 for _, N, K in mnk) or any(
+            n == 2880 and k == 2880 for _, n, k in mnk
+        )
+
+    def test_moe_per_expert_M_smaller_than_dense_M(self):
+        cfg = _gpt_oss_20b_config()
+        shapes = extract_shapes(cfg, batch=1, seq=2048, ops=["mxfp4_fwd"])
+        # Dense M = 2048; per-expert M = ceil(2048 * top_k / num_experts) =
+        # ceil(2048 * 4 / 32) = 256.
+        ms = {M for _, M, _, _ in shapes}
+        assert 256 in ms or any(M < 2048 for M in ms)
+
+
+class TestExtractShapesValidation:
+    def test_empty_ops_rejected(self):
+        cfg = _qwen3_8b_config()
+        with pytest.raises(ValueError):
+            extract_shapes(cfg, batch=1, seq=4096, ops=[])
+
+    def test_zero_batch_rejected(self):
+        cfg = _qwen3_8b_config()
+        with pytest.raises(ValueError):
+            extract_shapes(cfg, batch=0, seq=4096)
+
+    def test_negative_seq_rejected(self):
+        cfg = _qwen3_8b_config()
+        with pytest.raises(ValueError):
+            extract_shapes(cfg, batch=1, seq=-1)
+
+    def test_unknown_arch_rejected(self):
+        # No hidden_size, no intermediate_size -- can't synthesize shapes.
+        cfg = _make_config("WeirdConfig")
+        with pytest.raises(ValueError):
+            extract_shapes(cfg, batch=1, seq=128)
+
+    def test_generic_fallback_uses_dense_extractor(self):
+        # An arch we don't explicitly recognize but has the right attributes
+        # falls back to the dense path -- silent default for new HF configs.
+        cfg = _make_config(
+            "FutureConfig",
+            hidden_size=2048,
+            intermediate_size=8192,
+            num_attention_heads=16,
+            num_key_value_heads=4,
+            head_dim=128,
+        )
+        shapes = extract_shapes(cfg, batch=1, seq=512, ops=["mxfp4_fwd"])
+        assert shapes, "fallback path should still produce shapes"
+
+
+# ---------------------------------------------------------------------------
+# model_basename
+# ---------------------------------------------------------------------------
+
+
+class TestModelBasename:
+    def test_hf_id(self):
+        assert model_basename("Qwen/Qwen3-8B") == "Qwen3-8B"
+
+    def test_local_path(self):
+        assert model_basename("/home/x/Models/Qwen3-8B") == "Qwen3-8B"
+
+    def test_trailing_slash(self):
+        assert model_basename("/home/x/Models/Qwen3-8B/") == "Qwen3-8B"
+
+    def test_empty(self):
+        assert model_basename("") == "model"
+
+    def test_simple_name(self):
+        assert model_basename("Qwen3-8B") == "Qwen3-8B"


### PR DESCRIPTION
## Summary

Adds \`kernel-anvil train-optimize\` — the kernel-anvil side of the training-kernel autotune feature. Profiles training-time MXFP4 / INT4 forward + grad-input shapes for a Hugging Face model and writes anvil-train JSON v1 configs that mud-puppy's \`anvil_loader\` consumes.

Companion PR: Tuklus-Labs/mud-puppy#2 (mud-puppy-side loader + kernel patches). Implementation plan: \`docs/plans/2026-04-28-kernel-anvil-training-impl.md\` in that PR.

## What's in this PR

### New
- \`kernel_anvil/train_codegen.py\` — stdlib-only JSON v1 codegen (schema, 3D 5×5×5 bucket helpers, \`TrainShapeConfig\`, \`build_op_table\`, \`generate_train_runtime_config\`, \`merge_train_runtime_configs\`).
- \`kernel_anvil/train_shapes.py\` — HF-config → \`(op, M, N, K)\` shape extractor for \`LlamaConfig\`, \`Qwen3Config\`, and \`GptOssConfig\` (MoE bucketed).
- \`kernel_anvil/train_param_space.py\` — RDNA3-aware Triton config grid filtered by VGPR/LDS budget; capped at 30 candidates per shape.

### Extended
- \`kernel_anvil/cli.py\` — \`cmd_train_optimize\` and the \`train-optimize\` subparser. Atomic JSON write to \`~/.cache/anvil-train/<gpu>/<model>-<quant>-bBsS.json\`. Loads runners from mud-puppy via \`--mud-puppy-path <path>\` (no hard dependency). \`--dry-run\` produces a JSON skeleton without GPU for testing the JSON layer.
- \`kernel_anvil/verify.py\` — accepts tuple/list/dict outputs with an \`output_index\` parameter (grad-input may return more than one tensor).
- \`README.md\` — new \"Tune training-time kernels (mud-puppy)\" subsection.

## Tests

- \`tests/test_train_codegen.py\` (28 tests) — bucket math, build_op_table, generate/merge JSON, malformed-input defenses.
- \`tests/test_train_shapes.py\` (13 tests) — shape extraction against fixture HF configs (no network).
- \`tests/test_train_cli.py\` (14 tests) — \`--help\`, error paths, mocked extract_shapes, \`--dry-run\` JSON structure.
- **330 passed (was 275 / +55 new), 0 regressions.**

## Notes
- \`kernel_hash\` is left empty in the v1 JSON; computing it on the mud-puppy side (where the kernel source lives) is cleaner. The mud-puppy loader does the hash check.
- Runner contract was extended to accept an optional \`make_inputs(M, N, K)\` so a single runner module can serve every shape; the legacy no-arg \`setup()\` still works.
- No CDNA support yet — Gary scoped this work to RDNA. CDNA is a follow-up via a fresh GPU-spec module.

## Test plan
- [x] \`python -m pytest -q\` (330 passed / 13 skipped)
- [x] \`python -m kernel_anvil train-optimize --help\`
- [x] \`python -m kernel_anvil train-optimize Qwen3-8B --quant mxfp4 --batch 1 --seq 4096 --dry-run\` produces valid v1 JSON skeleton
- [ ] End-to-end with mud-puppy installed: \`kernel-anvil train-optimize Qwen3-8B --mud-puppy-path ~/Projects/mud-puppy ...\` actually runs the GPU sweep

🤖 Generated with [Claude Code](https://claude.com/claude-code)