### PR TITLE
Junkman690 router support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ On startup:
 kernel-anvil: loaded 6 shape configs from ~/.cache/smithy/Qwen3-8B-Q4_K_M.json
 ```
 
+### To support multiple optimized configs when in router mode
+
+my-models.ini
+```
+smithy-config = ~/.cache/smithy/Qwen3-8B-Q4_K_M.json
+```
+
+```bash
+llama-server --models-preset ./my-models.ini
+```
+
 ### Speculative decoding (target + draft)
 
 llama.cpp's speculative decoding loads two models concurrently (a large target plus a small draft). Both run through the same MMVQ dispatch path, so a single merged config covers both.

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,6 +4,22 @@ This patch adds runtime shape-specific MMVQ kernel configuration to llama.cpp.
 When kernel-anvil generates optimized configs for your model + GPU, this patch
 lets llama.cpp load them at startup.
 
+## Patch Files
+
+| File | Target | Required | Purpose |
+|------|--------|----------|---------|
+| `smithy-config.h` | `ggml/src/ggml-cuda/` | Yes | Config loader header (3-tier JSON lookup) |
+| `mmvq-smithy.patch` | `ggml/src/ggml-cuda/mmvq.cu` | Yes | Hooks `smithy_lookup()` into MMVQ dispatch |
+| `arg-h-smithy-router.patch` | `common/arg.h` | No | Registers `smithy-config` pseudo-env for models.ini |
+| `arg-cpp-smithy-router.patch` | `common/arg.cpp` | No | Accepts `smithy-config` as a preset-only INI option |
+| `server-models-cpp-smithy-router.patch` | `tools/server/server-models.cpp` | No | Injects `SMITHY_CONFIG` env at child spawn |
+
+The three `*-router.patch` files enable per-model smithy config in llama.cpp's
+router mode (multiple models loaded concurrently). They are applied
+automatically by `apply.sh` when the llama.cpp source supports router mode;
+on older trees they are silently skipped and the single-model `SMITHY_CONFIG`
+env var still works.
+
 ## Requirements
 
 `smithy-config.h` requires **C++17** (uses `std::atomic`, `std::shared_mutex`,
@@ -120,4 +136,60 @@ Generate configs with:
 kernel-anvil gguf-optimize model.gguf
 # or for full benchmarking:
 kernel-anvil autoforge model.gguf --llama-cpp-path /path/to/llama.cpp
+```
+
+## Router Mode (Per-Model Configs)
+
+When running `llama-server` in router mode (multiple models loaded
+concurrently), the `SMITHY_CONFIG` env var is process-wide and cannot vary
+per model. The three `*-router.patch` files add a `smithy-config` key to
+`models.ini` so each model section can point to its own config JSON:
+
+```ini
+[unsloth/Qwen3.6-27B-MTP-Vulkan-GGUF:Q8_K_XL]
+smithy-config = ~/.cache/smithy/Qwen3.6-27B-MTP-Vulkan-GGUF.json
+
+[satgeze/Hy3-1M-GGUF-tuned:Q4_K_M]
+smithy-config = /models/smithy-cache/Hy3-1M-GGUF-tuned.json
+```
+
+### How it works
+
+1. `arg-h-smithy-router.patch` + `arg-cpp-smithy-router.patch` register
+   `smithy-config` as a preset-only INI option (like `load-on-startup`).
+   This passes the INI parser's key validation without adding a CLI arg.
+2. `server-models-cpp-smithy-router.patch` reads the value at child spawn
+   and injects it as `SMITHY_CONFIG=<path>` into the child process
+   environment.
+3. The child's existing `smithy-config.h` picks up `SMITHY_CONFIG` as
+   priority 1 in its 3-tier lookup — no changes to the loader needed.
+
+Models without a `smithy-config` key fall back to the default lookup chain
+(per-model-stem JSON, then `default.json`).
+
+### Manual Apply (if router patches don't apply via `apply.sh`)
+
+**`common/arg.h`** — add after the existing `COMMON_ARG_PRESET_*` defines:
+```cpp
+#define COMMON_ARG_PRESET_SMITHY_CONFIG  "__PRESET_SMITHY_CONFIG"
+```
+
+**`common/arg.cpp`** — in `common_params_add_preset_options()`, add after the
+`stop-timeout` entry:
+```cpp
+args.push_back(common_arg(
+    {"smithy-config"}, "PATH",
+    "path to smithy per-model kernel config JSON (router mode: injected as SMITHY_CONFIG env for the child process)",
+    [](common_params &, const std::string &) { /* unused */ }
+).set_env(COMMON_ARG_PRESET_SMITHY_CONFIG).set_preset_only());
+```
+
+**`tools/server/server-models.cpp`** — in `server_models::load()`, after
+`child_env = base_env;` and the `LLAMA_SERVER_ROUTER_PORT` push:
+```cpp
+// Inject per-model smithy config as SMITHY_CONFIG env var for the child
+std::string smithy_path;
+if (inst.meta.preset.get_option(COMMON_ARG_PRESET_SMITHY_CONFIG, smithy_path) && !smithy_path.empty()) {
+    child_env.push_back("SMITHY_CONFIG=" + smithy_path);
+}
 ```

--- a/patches/apply.sh
+++ b/patches/apply.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 # Apply kernel-anvil runtime config patch to llama.cpp
 # Usage: ./apply.sh /path/to/llama.cpp
+#
+# Applies in two phases:
+#   1. Core MMVQ patch (required) — adds smithy-config.h + kernel dispatch hook
+#   2. Router-mode patches (optional) — enables per-model smithy-config in models.ini
+#      If the router patches don't apply (older llama.cpp without router mode,
+#      or upstream API drift), the core single-model SMITHY_CONFIG flow still works.
 
 set -e
 
@@ -58,6 +64,37 @@ else
     exit 1
 fi
 
+# ── Router-mode patches (optional) ──────────────────────────────────────
+# Enables `smithy-config = <path>` per model section in models.ini. The router
+# injects SMITHY_CONFIG as an env var when spawning each child process.
+# Non-fatal: if these don't apply (older llama.cpp without router mode, or
+# upstream API drift), the core single-model SMITHY_CONFIG env var still works.
+ROUTER_PATCHES=(
+    arg-h-smithy-router.patch
+    arg-cpp-smithy-router.patch
+    server-models-cpp-smithy-router.patch
+)
+ROUTER_APPLIED=0
+ROUTER_FAILED=0
+
+for p in "${ROUTER_PATCHES[@]}"; do
+    if [ ! -f "$SCRIPT_DIR/$p" ]; then
+        echo "Warning: $p not found, skipping"
+        ROUTER_FAILED=1
+        continue
+    fi
+    if git apply --check "$SCRIPT_DIR/$p" 2>/dev/null; then
+        git apply "$SCRIPT_DIR/$p"
+        echo "Applied $p"
+        ROUTER_APPLIED=$((ROUTER_APPLIED + 1))
+    else
+        echo "Warning: $p doesn't apply cleanly (llama.cpp version mismatch or no router mode)."
+        echo "  Per-model smithy-config in models.ini will not be available."
+        echo "  Single-model SMITHY_CONFIG env var still works."
+        ROUTER_FAILED=1
+    fi
+done
+
 echo ""
 echo "Done! Now rebuild llama.cpp with HIP:"
 echo "  cd $LLAMA_CPP"
@@ -67,3 +104,9 @@ echo ""
 echo "Then run with kernel-anvil configs:"
 echo "  kernel-anvil gguf-optimize model.gguf"
 echo "  SMITHY_CONFIG=~/.cache/smithy/model.json ./build/bin/llama-server -m model.gguf -ngl 999"
+if [ "$ROUTER_APPLIED" -gt 0 ] && [ "$ROUTER_FAILED" -eq 0 ]; then
+    echo ""
+    echo "Router mode (per-model configs via models.ini):"
+    echo "  Add 'smithy-config = ~/.cache/smithy/model.json' to each model section"
+    echo "  See patches/README.md for details"
+fi

--- a/patches/arg-cpp-smithy-router.patch
+++ b/patches/arg-cpp-smithy-router.patch
@@ -1,0 +1,15 @@
+--- a/common/arg.cpp
++++ b/common/arg.cpp
+@@ -4568,6 +4568,12 @@
+         [](common_params &, int) { /* unused */ }
+     ).set_env(COMMON_ARG_PRESET_STOP_TIMEOUT).set_preset_only());
+ 
++    args.push_back(common_arg(
++        {"smithy-config"}, "PATH",
++        "path to smithy per-model kernel config JSON (router mode: injected as SMITHY_CONFIG env for the child process)",
++        [](common_params &, const std::string &) { /* unused */ }
++    ).set_env(COMMON_ARG_PRESET_SMITHY_CONFIG).set_preset_only());
++
+     // args.push_back(common_arg(
+     //     {"pin"},
+     //     "in server router mode, do not unload this model if models_max is exceeded",

--- a/patches/arg-h-smithy-router.patch
+++ b/patches/arg-h-smithy-router.patch
@@ -1,0 +1,10 @@
+--- a/common/arg.h
++++ b/common/arg.h
+@@ -13,6 +13,7 @@
+ // pseudo-env variable to identify preset-only arguments
+ #define COMMON_ARG_PRESET_LOAD_ON_STARTUP "__PRESET_LOAD_ON_STARTUP"
+ #define COMMON_ARG_PRESET_STOP_TIMEOUT    "__PRESET_STOP_TIMEOUT"
++#define COMMON_ARG_PRESET_SMITHY_CONFIG  "__PRESET_SMITHY_CONFIG"
+ 
+ //
+ // CLI argument parsing

--- a/patches/server-models-cpp-smithy-router.patch
+++ b/patches/server-models-cpp-smithy-router.patch
@@ -1,0 +1,15 @@
+--- a/tools/server/server-models.cpp
++++ b/tools/server/server-models.cpp
+@@ -802,6 +802,12 @@
+         std::vector<std::string> child_env  = base_env; // copy
+         child_env.push_back("LLAMA_SERVER_ROUTER_PORT=" + std::to_string(base_params.port));
+ 
++        // Inject per-model smithy config as SMITHY_CONFIG env var for the child
++        std::string smithy_path;
++        if (inst.meta.preset.get_option(COMMON_ARG_PRESET_SMITHY_CONFIG, smithy_path) && !smithy_path.empty()) {
++            child_env.push_back("SMITHY_CONFIG=" + smithy_path);
++        }
++
+         if (opts.mode == SERVER_CHILD_MODE_DOWNLOAD) {
+             inst.meta.status = SERVER_MODEL_STATUS_DOWNLOADING;
+             child_env.push_back("LLAMA_SERVER_CHILD_MODE=download");


### PR DESCRIPTION
Added support for to specify the smithy config per model when running in router mode. Allows you to run per model config rather than relying on a merged file for multiple models. Existing config selection logic remains and you can still have a merged "default" config as fallback if no config is passed for the model that is currently loading.